### PR TITLE
prepare for release

### DIFF
--- a/io_mesh_w3d/__init__.py
+++ b/io_mesh_w3d/__init__.py
@@ -7,12 +7,12 @@ from bpy_extras.io_utils import ImportHelper, ExportHelper
 from io_mesh_w3d.export_utils import save_data
 from io_mesh_w3d.custom_properties import *
 
-VERSION = (0, 5, 1)
+VERSION = (0, 6, 0)
 
 bl_info = {
     'name': 'Import/Export Westwood W3D Format (.w3d/.w3x)',
     'author': 'OpenSage Developers',
-    'version': (0, 5, 1),
+    'version': (0, 6, 0),
     "blender": (2, 83, 0),
     'location': 'File > Import/Export > Westwood W3D (.w3d/.w3x)',
     'description': 'Import or Export the Westwood W3D-Format (.w3d/.w3x)',

--- a/io_mesh_w3d/w3d/export_w3d.py
+++ b/io_mesh_w3d/w3d/export_w3d.py
@@ -47,7 +47,7 @@ def save(context, export_settings, data_context):
         data_context.animation.write(file)
 
     elif export_mode == 'H':
-        data_context.hierarchy.header.name = data_context.container_name
+        data_context.hierarchy.header.name = data_context.container_name.upper()
         data_context.hierarchy.write(file)
     else:
         context.error('unsupported export mode: ' + export_mode + ', aborting export!')

--- a/io_mesh_w3d/w3d/structs/compressed_animation.py
+++ b/io_mesh_w3d/w3d/structs/compressed_animation.py
@@ -14,8 +14,8 @@ class CompressedAnimationHeader:
     def __init__(
             self,
             version=Version(
-                major=1,
-                minor=0),
+                major=0,
+                minor=1),
             name='',
             hierarchy_name='',
             num_frames=0,
@@ -43,9 +43,7 @@ class CompressedAnimationHeader:
         return const_size(44, include_head)
 
     def write(self, io_stream):
-        write_chunk_head(
-            W3D_CHUNK_COMPRESSED_ANIMATION_HEADER, io_stream,
-            self.size(False))
+        write_chunk_head(W3D_CHUNK_COMPRESSED_ANIMATION_HEADER, io_stream, self.size(False)) #16
         self.version.write(io_stream)
         write_fixed_string(self.name, io_stream)
         write_fixed_string(self.hierarchy_name, io_stream)
@@ -55,7 +53,7 @@ class CompressedAnimationHeader:
 
 
 class TimeCodedDatum:
-    def __init__(self, time_code=0, interpolated=True, value=None):
+    def __init__(self, time_code=0, interpolated=False, value=None):
         self.time_code = time_code
         self.interpolated = interpolated
         self.value = value
@@ -411,7 +409,7 @@ class CompressedAnimation:
         result = CompressedAnimation(header=None)
 
         while io_stream.tell() < chunk_end:
-            (chunk_type, chunk_size, _) = read_chunk_head(io_stream)
+            chunk_type, chunk_size, _ = read_chunk_head(io_stream)
             if chunk_type == W3D_CHUNK_COMPRESSED_ANIMATION_HEADER:
                 result.header = CompressedAnimationHeader.read(io_stream)
             elif chunk_type == W3D_CHUNK_COMPRESSED_ANIMATION_CHANNEL:

--- a/io_mesh_w3d/w3x/export_w3x.py
+++ b/io_mesh_w3d/w3x/export_w3x.py
@@ -101,7 +101,7 @@ def save(context, export_settings, data_context):
         data_context.animation.create(root)
 
     elif export_mode == 'H':
-        data_context.hierarchy.header.name = data_context.container_name
+        data_context.hierarchy.header.name = data_context.container_name.upper()
         data_context.hierarchy.create(root)
 
     else:

--- a/tests/w3d/cases/test_roundtrip.py
+++ b/tests/w3d/cases/test_roundtrip.py
@@ -56,9 +56,9 @@ class TestRoundtripW3D(TestCase):
         load(self)
 
         # check created objects
-        self.assertTrue(hierarchy_name in bpy.data.objects)
-        self.assertTrue(hierarchy_name in bpy.data.armatures)
-        amt = bpy.data.armatures[hierarchy_name]
+        self.assertTrue(hierarchy_name.upper() in bpy.data.objects)
+        self.assertTrue(hierarchy_name.upper()in bpy.data.armatures)
+        amt = bpy.data.armatures[hierarchy_name.upper()]
         self.assertEqual(7, len(amt.bones))
 
         self.assertTrue('sword' in bpy.data.objects)
@@ -105,9 +105,9 @@ class TestRoundtripW3D(TestCase):
         load(self)
 
         # check created objects
-        self.assertTrue(hierarchy_name in bpy.data.objects)
-        self.assertTrue(hierarchy_name in bpy.data.armatures)
-        amt = bpy.data.armatures[hierarchy_name]
+        self.assertTrue(hierarchy_name.upper() in bpy.data.objects)
+        self.assertTrue(hierarchy_name.upper() in bpy.data.armatures)
+        amt = bpy.data.armatures[hierarchy_name.upper()]
         self.assertEqual(7, len(amt.bones))
 
         self.assertTrue('sword' in bpy.data.objects)

--- a/tests/w3d/helpers/compressed_animation.py
+++ b/tests/w3d/helpers/compressed_animation.py
@@ -11,7 +11,7 @@ from tests.w3d.helpers.version import get_version, compare_versions
 def get_compressed_animation_header(
         hierarchy_name='hierarchy', flavor=ADAPTIVE_DELTA_FLAVOR):
     return CompressedAnimationHeader(
-        version=get_version(major=1, minor=0),
+        version=get_version(major=0, minor=1),
         name='containerName',
         hierarchy_name=hierarchy_name,
         num_frames=155,

--- a/tests/w3x/cases/test_roundtrip.py
+++ b/tests/w3x/cases/test_roundtrip.py
@@ -59,9 +59,9 @@ class TestRoundtripW3X(TestCase):
         load(self)
 
         # check created objects
-        self.assertTrue(hierarchy_name in bpy.data.objects)
-        self.assertTrue(hierarchy_name in bpy.data.armatures)
-        amt = bpy.data.armatures[hierarchy_name]
+        self.assertTrue(hierarchy_name.upper() in bpy.data.objects)
+        self.assertTrue(hierarchy_name.upper() in bpy.data.armatures)
+        amt = bpy.data.armatures[hierarchy_name.upper()]
         self.assertEqual(7, len(amt.bones))
 
         self.assertTrue('sword' in bpy.data.objects)

--- a/version_history.txt
+++ b/version_history.txt
@@ -1,4 +1,4 @@
-v0.5.1
+v0.6.0
 - export dummy shade indices (they are needed for the mod SDK (at least for W3X))
 - support for mesh sorting levels
 - only display appropriate custom object properties
@@ -9,6 +9,8 @@ v0.5.1
 - Bugfix: fix import of visibility channels of armature
 - Bugfix: handle multiple hlod, hierarchy and animation chunks
 - Bugfix: fix export when bones are not in tree order
+- Bugfix: fix export of time coded animations
+- Bugfix: set hierarchy name always uppercase
 
 v0.5.0 (10.06.20)
 - use proper enums for vertex material shader properties


### PR DESCRIPTION
Bugfix: fix export of time coded animations 

- timecoded flag is false by default
- set correct version number

Bugfix: set hierarchy name always uppercase