### PR TITLE
initial work on fixing uv-splitting issue

### DIFF
--- a/io_mesh_w3d/common/utils/mesh_export.py
+++ b/io_mesh_w3d/common/utils/mesh_export.py
@@ -316,12 +316,16 @@ def prepare_bmesh(context, mesh):
     bmesh.ops.triangulate(b_mesh, faces=b_mesh.faces)
     b_mesh.to_mesh(mesh)
     b_mesh.free()
+    mesh.update()
+    print(f'new verts: {len(mesh.vertices)}')
 
     while split_multi_uv_vertices(context, mesh, b_mesh):
         time.sleep(2)
         context.info(f'mesh \'{mesh.name}\' vertices have been split because of multiple uv coordinates per vertex!')
+
     b_mesh = bmesh.new()
     b_mesh.from_mesh(mesh)
+    mesh.update()
     return b_mesh
 
 
@@ -331,7 +335,7 @@ def find_bone_index(hierarchy, mesh_object, group):
 
 
 def split_multi_uv_vertices(context, mesh, b_mesh):
-    mesh.update()
+    print('###   run')
     if mesh.validate(verbose=True):
         context.info(f'mesh \'{mesh_struct.name()}\' has been fixed')
     b_mesh = bmesh.new()
@@ -358,6 +362,7 @@ def split_multi_uv_vertices(context, mesh, b_mesh):
         bmesh.ops.split_edges(b_mesh, edges=split_edges)
 
     b_mesh.to_mesh(mesh)
+    mesh.update()
     return len(split_edges) > 0
 
 

--- a/io_mesh_w3d/common/utils/mesh_export.py
+++ b/io_mesh_w3d/common/utils/mesh_export.py
@@ -1,6 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
+import time
+
 import bpy
 import bmesh
 from mathutils import Vector, Matrix
@@ -315,11 +317,11 @@ def prepare_bmesh(context, mesh):
     b_mesh.to_mesh(mesh)
     b_mesh.free()
 
+    while split_multi_uv_vertices(context, mesh, b_mesh):
+        time.sleep(2)
+        context.info(f'mesh \'{mesh.name}\' vertices have been split because of multiple uv coordinates per vertex!')
     b_mesh = bmesh.new()
     b_mesh.from_mesh(mesh)
-    b_mesh = split_multi_uv_vertices(context, mesh, b_mesh)
-    b_mesh.to_mesh(mesh)
-
     return b_mesh
 
 
@@ -329,6 +331,11 @@ def find_bone_index(hierarchy, mesh_object, group):
 
 
 def split_multi_uv_vertices(context, mesh, b_mesh):
+    mesh.update()
+    if mesh.validate(verbose=True):
+        context.info(f'mesh \'{mesh_struct.name()}\' has been fixed')
+    b_mesh = bmesh.new()
+    b_mesh.from_mesh(mesh)
     b_mesh.verts.ensure_lookup_table()
 
     for ver in b_mesh.verts:
@@ -339,16 +346,19 @@ def split_multi_uv_vertices(context, mesh, b_mesh):
         for j, face in enumerate(b_mesh.faces):
             for loop in face.loops:
                 vert_index = mesh.polygons[j].vertices[loop.index % 3]
-                if tx_coords[vert_index] is not None \
-                        and tx_coords[vert_index] != uv_layer.data[loop.index].uv:
+                if tx_coords[vert_index] is None:
+                    tx_coords[vert_index] = uv_layer.data[loop.index].uv
+                elif tx_coords[vert_index] != uv_layer.data[loop.index].uv:
                     b_mesh.verts[vert_index].select_set(True)
-                tx_coords[vert_index] = uv_layer.data[loop.index].uv
 
     split_edges = [e for e in b_mesh.edges if e.verts[0].select and e.verts[1].select]
-    if split_edges:
+    print(len(split_edges))
+
+    if len(split_edges) > 0:
         bmesh.ops.split_edges(b_mesh, edges=split_edges)
-        context.info(f'mesh \'{mesh.name}\' vertices have been split because of multiple uv coordinates per vertex!')
-    return b_mesh
+
+    b_mesh.to_mesh(mesh)
+    return len(split_edges) > 0
 
 
 def vertices_to_vectors(vertices):

--- a/io_mesh_w3d/common/utils/mesh_export.py
+++ b/io_mesh_w3d/common/utils/mesh_export.py
@@ -1,8 +1,6 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-import time
-
 import bpy
 import bmesh
 from mathutils import Vector, Matrix
@@ -315,17 +313,13 @@ def prepare_bmesh(context, mesh):
     b_mesh.from_mesh(mesh)
     bmesh.ops.triangulate(b_mesh, faces=b_mesh.faces)
     b_mesh.to_mesh(mesh)
-    b_mesh.free()
     mesh.update()
-    print(f'num verts: {len(mesh.vertices)}')
-
-    if split_multi_uv_vertices(context, mesh, b_mesh):
-        context.info(f'mesh \'{mesh.name}\' vertices have been split because of multiple uv coordinates per vertex!')
 
     b_mesh = bmesh.new()
     b_mesh.from_mesh(mesh)
+    b_mesh = split_multi_uv_vertices(context, mesh, b_mesh)
+    b_mesh.to_mesh(mesh)
     mesh.update()
-    print(f'num new verts: {len(mesh.vertices)}')
     return b_mesh
 
 
@@ -335,8 +329,6 @@ def find_bone_index(hierarchy, mesh_object, group):
 
 
 def split_multi_uv_vertices(context, mesh, b_mesh):
-    b_mesh = bmesh.new()
-    b_mesh.from_mesh(mesh)
     b_mesh.verts.ensure_lookup_table()
 
     for ver in b_mesh.verts:
@@ -360,11 +352,9 @@ def split_multi_uv_vertices(context, mesh, b_mesh):
 
     if len(split_edges) > 0:
         bmesh.ops.split_edges(b_mesh, edges=split_edges)
+        context.info(f'mesh \'{mesh.name}\' vertices have been split because of multiple uv coordinates per vertex!')
 
-    b_mesh.to_mesh(mesh)
-    mesh.update()
-    return len(split_edges) > 0
-
+    return b_mesh
 
 def vertices_to_vectors(vertices):
     vectors = []

--- a/io_mesh_w3d/common/utils/mesh_export.py
+++ b/io_mesh_w3d/common/utils/mesh_export.py
@@ -317,15 +317,15 @@ def prepare_bmesh(context, mesh):
     b_mesh.to_mesh(mesh)
     b_mesh.free()
     mesh.update()
-    print(f'new verts: {len(mesh.vertices)}')
+    print(f'num verts: {len(mesh.vertices)}')
 
-    while split_multi_uv_vertices(context, mesh, b_mesh):
-        time.sleep(2)
+    if split_multi_uv_vertices(context, mesh, b_mesh):
         context.info(f'mesh \'{mesh.name}\' vertices have been split because of multiple uv coordinates per vertex!')
 
     b_mesh = bmesh.new()
     b_mesh.from_mesh(mesh)
     mesh.update()
+    print(f'num new verts: {len(mesh.vertices)}')
     return b_mesh
 
 
@@ -335,9 +335,6 @@ def find_bone_index(hierarchy, mesh_object, group):
 
 
 def split_multi_uv_vertices(context, mesh, b_mesh):
-    print('###   run')
-    if mesh.validate(verbose=True):
-        context.info(f'mesh \'{mesh_struct.name()}\' has been fixed')
     b_mesh = bmesh.new()
     b_mesh.from_mesh(mesh)
     b_mesh.verts.ensure_lookup_table()
@@ -354,9 +351,12 @@ def split_multi_uv_vertices(context, mesh, b_mesh):
                     tx_coords[vert_index] = uv_layer.data[loop.index].uv
                 elif tx_coords[vert_index] != uv_layer.data[loop.index].uv:
                     b_mesh.verts[vert_index].select_set(True)
+                    vert_index2 = mesh.polygons[j].vertices[(loop.index + 1) % 3]
+                    b_mesh.verts[vert_index2].select_set(True)
+                    vert_index3 = mesh.polygons[j].vertices[(loop.index - 1) % 3]
+                    b_mesh.verts[vert_index3].select_set(True)
 
     split_edges = [e for e in b_mesh.edges if e.verts[0].select and e.verts[1].select]
-    print(len(split_edges))
 
     if len(split_edges) > 0:
         bmesh.ops.split_edges(b_mesh, edges=split_edges)

--- a/tests/common/cases/utils/test_mesh_export.py
+++ b/tests/common/cases/utils/test_mesh_export.py
@@ -46,7 +46,7 @@ class TestMeshExportUtils(TestCase):
         self.assertEqual(42, len(mesh.verts))
 
         mesh2 = meshes[1]
-        self.assertEqual(34, len(mesh2.verts))
+        self.assertEqual(161, len(mesh2.verts))
 
     def test_trianglulation_of_sphere(self):
         mesh = bpy.data.meshes.new('sphere')

--- a/tests/common/cases/utils/test_mesh_export.py
+++ b/tests/common/cases/utils/test_mesh_export.py
@@ -208,6 +208,24 @@ class TestMeshExportUtils(TestCase):
             retrieve_meshes(self, None, None, 'container_name')
             report_func.assert_called_with('mesh \'mesh\' uses a invalid/empty material!')
 
+    def test_multi_uv_vertex_splitting_no_splitting_if_uv_coords_match(self):
+        mesh = bpy.data.meshes.new('mesh')
+
+        b_mesh = bmesh.new()
+        bmesh.ops.create_cube(b_mesh, size=1)
+        b_mesh.to_mesh(mesh)
+
+        tx_coords = [get_vec2(0.0, 0.0)] * 24
+
+        uv_layer = mesh.uv_layers.new(do_init=False)
+        for i, datum in enumerate(uv_layer.data):
+            datum.uv = tx_coords[i]
+
+        _mesh = prepare_bmesh(self, mesh)
+
+        self.assertEqual(8, len(_mesh.verts))
+        self.assertEqual(12, len(_mesh.faces))
+
     def test_multi_uv_vertex_splitting(self):
         mesh = bpy.data.meshes.new('mesh')
 
@@ -216,29 +234,29 @@ class TestMeshExportUtils(TestCase):
         b_mesh.to_mesh(mesh)
 
         tx_coords = [get_vec2(0.0, 1.0),
-                     get_vec2(0.0, 0.0),
-                     get_vec2(1.0, 0.0),
-                     get_vec2(1.0, 1.0),
-                     get_vec2(1.0, 1.0),
-                     get_vec2(0.0, 1.0),
-                     get_vec2(0.0, 0.0),
-                     get_vec2(1.0, 0.0),
-                     get_vec2(1.0, 1.0),
-                     get_vec2(0.0, 1.0),
-                     get_vec2(0.0, 0.0),
-                     get_vec2(1.0, 0.0),
-                     get_vec2(1.0, 1.0),
-                     get_vec2(0.0, 1.0),
-                     get_vec2(0.0, 0.0),
-                     get_vec2(1.0, 0.0),
-                     get_vec2(1.0, 1.0),
-                     get_vec2(0.0, 1.0),
-                     get_vec2(0.0, 0.0),
-                     get_vec2(1.0, 0.0),
-                     get_vec2(1.0, 1.0),
-                     get_vec2(0.0, 1.0),
-                     get_vec2(0.0, 0.0),
-                     get_vec2(1.0, 0.0)]
+                     get_vec2(0.1, 0.0),
+                     get_vec2(1.2, 0.0),
+                     get_vec2(1.3, 1.0),
+                     get_vec2(1.4, 1.0),
+                     get_vec2(0.5, 1.0),
+                     get_vec2(0.6, 0.0),
+                     get_vec2(1.7, 0.0),
+                     get_vec2(1.8, 1.0),
+                     get_vec2(0.9, 1.0),
+                     get_vec2(0.10, 0.0),
+                     get_vec2(1.11, 0.0),
+                     get_vec2(1.12, 1.0),
+                     get_vec2(0.13, 1.0),
+                     get_vec2(0.14, 0.0),
+                     get_vec2(1.15, 0.0),
+                     get_vec2(1.16, 1.0),
+                     get_vec2(0.17, 1.0),
+                     get_vec2(0.18, 0.0),
+                     get_vec2(1.19, 0.0),
+                     get_vec2(1.20, 1.0),
+                     get_vec2(0.21, 1.0),
+                     get_vec2(0.22, 0.0),
+                     get_vec2(1.23, 0.0)]
 
         uv_layer = mesh.uv_layers.new(do_init=False)
         for i, datum in enumerate(uv_layer.data):
@@ -246,7 +264,63 @@ class TestMeshExportUtils(TestCase):
 
         _mesh = prepare_bmesh(self, mesh)
 
-        self.assertEqual(24, len(_mesh.verts))
+        self.assertEqual(36, len(_mesh.verts))
+        self.assertEqual(12, len(_mesh.faces))
+
+    def test_multi_uv_vertex_splitting_triangulated(self):
+        mesh = bpy.data.meshes.new('mesh')
+
+        b_mesh = bmesh.new()
+        bmesh.ops.create_cube(b_mesh, size=1)
+        bmesh.ops.triangulate(b_mesh, faces=b_mesh.faces)
+        b_mesh.to_mesh(mesh)
+
+        tx_coords = [get_vec2(0.0, 1.0),
+                     get_vec2(0.1, 0.0),
+                     get_vec2(1.2, 0.0),
+                     get_vec2(1.3, 1.0),
+                     get_vec2(1.4, 1.0),
+                     get_vec2(0.5, 1.0),
+                     get_vec2(0.6, 0.0),
+                     get_vec2(1.7, 0.0),
+                     get_vec2(1.8, 1.0),
+                     get_vec2(0.9, 1.0),
+                     get_vec2(0.10, 0.0),
+                     get_vec2(1.11, 0.0),
+                     get_vec2(1.12, 1.0),
+                     get_vec2(0.13, 1.0),
+                     get_vec2(0.14, 0.0),
+                     get_vec2(1.15, 0.0),
+                     get_vec2(1.16, 1.0),
+                     get_vec2(0.17, 1.0),
+                     get_vec2(0.18, 0.0),
+                     get_vec2(1.19, 0.0),
+                     get_vec2(1.20, 1.0),
+                     get_vec2(0.21, 1.0),
+                     get_vec2(0.22, 0.0),
+                     get_vec2(1.23, 0.0),
+                     get_vec2(1.24, 1.0),
+                     get_vec2(0.25, 1.0),
+                     get_vec2(0.26, 0.0),
+                     get_vec2(1.27, 0.0),
+                     get_vec2(1.28, 1.0),
+                     get_vec2(0.29, 1.0),
+                     get_vec2(0.30, 0.0),
+                     get_vec2(1.31, 0.0),
+                     get_vec2(1.32, 0.0),
+                     get_vec2(1.33, 1.0),
+                     get_vec2(0.34, 1.0),
+                     get_vec2(0.35, 0.0)]
+
+        uv_layer = mesh.uv_layers.new(do_init=False)
+        print(len(mesh.vertices))
+        print(len(uv_layer.data))
+        for i, datum in enumerate(uv_layer.data):
+            datum.uv = tx_coords[i]
+
+        _mesh = prepare_bmesh(self, mesh)
+
+        self.assertEqual(36, len(_mesh.verts))
         self.assertEqual(12, len(_mesh.faces))
 
     def test_mesh_with_unconnected_vertex_export(self):

--- a/tests/common/cases/utils/test_mesh_export.py
+++ b/tests/common/cases/utils/test_mesh_export.py
@@ -313,8 +313,7 @@ class TestMeshExportUtils(TestCase):
                      get_vec2(0.35, 0.0)]
 
         uv_layer = mesh.uv_layers.new(do_init=False)
-        print(len(mesh.vertices))
-        print(len(uv_layer.data))
+
         for i, datum in enumerate(uv_layer.data):
             datum.uv = tx_coords[i]
 

--- a/version_history.txt
+++ b/version_history.txt
@@ -13,7 +13,7 @@ v0.6.4 (23.3.21)
 - Bugfix: proper vertex material args handling
 - Bugfix: normalize quaternions on animation export
 
-v0.6.3 (17.1.2020)
+v0.6.3 (17.1.20)
 - geometry data can now be exported to xml and ini
 
 v0.6.2 (01.12.20)

--- a/version_history.txt
+++ b/version_history.txt
@@ -2,6 +2,7 @@ v0.6.5
 - cancel export if a mesh and a bone share the same name
 - Bugfix: handling of specular and emission color
 - Bugfix: use proper file extension for loaded textures
+- Bugfix: split vertices with n uv-coords into n vertices
 
 v0.6.4 (23.3.21)
 - support mesh property 'two sided'


### PR DESCRIPTION
Before a vertex was split into two vertices if it had > 2 uv coordinates. Now if a vertex has N uv coords it is split into N vertices.

- [x] fix failing unittests
- [x] write test for this exact issue
- [x] update version history