### PR TITLE
Fixed texture extension issue

### DIFF
--- a/io_mesh_w3d/common/utils/helpers.py
+++ b/io_mesh_w3d/common/utils/helpers.py
@@ -91,22 +91,29 @@ def create_uvlayer(context, mesh, b_mesh, tris, mat_pass):
             uv_layer.data[loop.index].uv = tx_coords[idx].xy
 
 
+extensions = ['.dds', '.tga', '.jpg', '.jpeg', '.png', '.bmp']
+
 def find_texture(context, file, name=None):
+    file = file.rsplit('.', 1)[0]
     if name is None:
         name = file
+    else:
+        name = name.rsplit('.', 1)[0]
 
-    file = file.split('.', -1)[0]
-    if name in bpy.data.images:
-        return bpy.data.images[name]
+    for extension in extensions:
+        combined = name + extension
+        if combined in bpy.data.images:
+            return bpy.data.images[combined]
 
     path = insensitive_path(os.path.dirname(context.filepath))
     filepath = path + os.path.sep + file
-    extensions = ['.dds', '.tga', '.jpg', '.jpeg', '.png', '.bmp']
+
     img = None
     for extension in extensions:
         img = load_image(filepath + extension)
         if img is not None:
             context.info('loaded texture: ' + filepath + extension)
+            img.name = name + extension
             break
 
     if img is None:
@@ -114,8 +121,8 @@ def find_texture(context, file, name=None):
         img = bpy.data.images.new(name, width=2048, height=2048)
         img.generated_type = 'COLOR_GRID'
         img.source = 'GENERATED'
+        img.name = name + extensions[0]
 
-    img.name = name
     img.alpha_mode = 'STRAIGHT'
     return img
 

--- a/tests/common/cases/test_utils.py
+++ b/tests/common/cases/test_utils.py
@@ -445,10 +445,10 @@ class TestUtils(TestCase):
             get_mesh(name='PICK')]
 
         copyfile(up(up(self.relpath())) + '/testfiles/texture.dds',
-                 self.outpath() + 'texture.tga')
+                 self.outpath() + 'texture.dds')
 
         copyfile(up(up(self.relpath())) + '/testfiles/texture.dds',
-                 self.outpath() + 'texture_nrm.tga')
+                 self.outpath() + 'texture_nrm.dds')
 
         create_data(self, meshes, hlod, hierarchy, boxes)
 

--- a/tests/common/cases/utils/test_helpers.py
+++ b/tests/common/cases/utils/test_helpers.py
@@ -32,10 +32,38 @@ class TestHelpers(TestCase):
 
                 report_func.assert_called()
 
+    def test_texture_file_extensions_is_dds_if_file_is_dds_but_tga_referenced(self):
+        with (patch.object(self, 'info')) as report_func:
+            for extension in extensions:
+                copyfile(up(up(up(self.relpath()))) + '/testfiles/texture.dds',
+                         self.outpath() + 'texture.dds')
+
+                find_texture(self, 'texture', 'texture.tga')
+
+                # reset scene
+                bpy.ops.wm.read_homefile(use_empty=True)
+                os.remove(self.outpath() + 'texture.dds')
+
+                report_func.assert_called_with(f'loaded texture: {self.outpath()}texture.dds')
+
+    def test_texture_file_extensions_is_tga_if_file_is_tga_but_dds_referenced(self):
+        with (patch.object(self, 'info')) as report_func:
+            for extension in extensions:
+                copyfile(up(up(up(self.relpath()))) + '/testfiles/texture.dds',
+                         self.outpath() + 'texture.tga')
+
+                find_texture(self, 'texture', 'texture.dds')
+
+                # reset scene
+                bpy.ops.wm.read_homefile(use_empty=True)
+                os.remove(self.outpath() + 'texture.tga')
+
+                report_func.assert_called_with(f'loaded texture: {self.outpath()}texture.tga')
+
     def test_invalid_texture_file_extension(self):
         extensions = ['.invalid']
 
-        with (patch.object(self, 'info')) as report_func:
+        with (patch.object(self, 'warning')) as report_func:
             for extension in extensions:
                 copyfile(up(up(up(self.relpath()))) + '/testfiles/texture.dds',
                          self.outpath() + 'texture' + extension)
@@ -46,7 +74,7 @@ class TestHelpers(TestCase):
                 bpy.ops.wm.read_homefile(use_empty=True)
                 os.remove(self.outpath() + 'texture' + extension)
 
-                report_func.assert_not_called()
+                report_func.assert_called()
 
     def test_call_create_uv_layer_without_tx_coords(self):
         fake_mat_pass = FakeClass()

--- a/version_history.txt
+++ b/version_history.txt
@@ -1,6 +1,7 @@
 v0.6.5
 - cancel export if a mesh and a bone share the same name
 - Bugfix: handling of specular and emission color
+- Bugfix: use proper file extension for loaded textures
 
 v0.6.4 (23.3.21)
 - support mesh property 'two sided'


### PR DESCRIPTION
There was an issue where the texture extension was accidentially set to .tga if the w3d model file references a .tga file but the actual file available is a .dds file.