### PR TITLE
handle naming issue properly

### DIFF
--- a/io_mesh_w3d/common/utils/mesh_export.py
+++ b/io_mesh_w3d/common/utils/mesh_export.py
@@ -26,12 +26,6 @@ def retrieve_meshes(context, hierarchy, rig, container_name, force_vertex_materi
         if mesh_object.data.object_type != 'MESH':
             continue
 
-        if mesh_object.name in bone_names and mesh_object.parent_bone == '':
-            naming_error = True
-            context.error(
-                f'mesh \'{mesh_object.name}\' has same name as bone \'{mesh_object.name}\'!')
-            continue
-
         if mesh_object.mode != 'OBJECT':
             bpy.ops.object.mode_set(mode='OBJECT')
 
@@ -282,6 +276,14 @@ def retrieve_meshes(context, hierarchy, rig, container_name, force_vertex_materi
                     header.attrs |= GEOMETRY_TYPE_CAMERA_ALIGNED
                     break
                 context.warning(f'mesh \'{mesh_object.name}\' constraint \'{constraint.name}\' is not supported!')
+
+        if mesh_object.name in bone_names:
+            if not (mesh_struct.is_skin() or mesh_object.parent_type == 'BONE' and mesh_object.parent_bone == mesh_object.name):
+                naming_error = True
+                context.error(
+                    f'mesh \'{mesh_object.name}\' has same name as bone \'{mesh_object.name}\' but is not configured properly!')
+                context.info('EITHER apply an armature modifier to it, create a vertex group with the same name as the mesh and do the weight painting OR set the armature as parent object and the identically named bone as parent bone.')
+                continue
 
         if mesh_struct.shader_materials:
             header.vert_channel_flags |= VERTEX_CHANNEL_TANGENT | VERTEX_CHANNEL_BITANGENT

--- a/version_history.txt
+++ b/version_history.txt
@@ -1,7 +1,7 @@
 v0.6.6
 
 v0.6.5 (26.3.21)
-- cancel export if a mesh and a bone share the same name
+- cancel export if a mesh and a bone share the same name and mesh is not configured properly
 - inform user if both vertex bone weights do not add up to 100%
 - Bugfix: handling of specular and emission color
 - Bugfix: use proper file extension for loaded textures


### PR DESCRIPTION
Turns out is a valid scenario that a mesh has the same name as a bone, but in that case the mesh has to be configured properly.
So it has to be either
- have an armature modifier, a vertex group with the same name as the mesh and valid bone weights
or
- have the armature object as parent and the parent bone must be the bone with the identical name