### PR TITLE
Animation issues

### DIFF
--- a/io_mesh_w3d/common/utils/animation_export.py
+++ b/io_mesh_w3d/common/utils/animation_export.py
@@ -27,7 +27,6 @@ def retrieve_channels(obj, hierarchy, timecoded, name=None):
     channels = []
 
     for fcu in obj.animation_data.action.fcurves:
-        print(fcu.data_path)
         if name is None:
             values = fcu.data_path.split('"')
             if len(values) == 1:
@@ -43,7 +42,6 @@ def retrieve_channels(obj, hierarchy, timecoded, name=None):
                 pivot_index = i
 
         channel_type = fcu.array_index
-        print(channel_type)
         vec_len = 1
 
         if is_rotation(fcu):

--- a/io_mesh_w3d/common/utils/animation_import.py
+++ b/io_mesh_w3d/common/utils/animation_import.py
@@ -22,6 +22,8 @@ def get_bone(rig, hierarchy, channel):
     if is_roottransform(channel):
         return rig
 
+    if channel.pivot >= len(hierarchy.pivots):
+        return None
     pivot = hierarchy.pivots[channel.pivot]
 
     if is_visibility(channel) and pivot.name in rig.data.bones:
@@ -52,9 +54,9 @@ def set_visibility(bone, frame, value):
     if isinstance(bone, bpy.types.Bone):
         bone.visibility = value
         bone.keyframe_insert(data_path='visibility', frame=frame, options=creation_options)
-    else:
-        bone.hide_viewport = bool(value)
-        bone.keyframe_insert(data_path='hide_viewport', frame=frame, options=creation_options)
+    #else:
+    #    bone.hide_viewport = bool(value)
+    #    bone.keyframe_insert(data_path='hide_viewport', frame=frame, options=creation_options)
 
 
 def set_keyframe(bone, channel, frame, value):
@@ -92,6 +94,8 @@ def apply_uncompressed(bone, channel):
 def process_channels(hierarchy, channels, rig, apply_func):
     for channel in channels:
         obj = get_bone(rig, hierarchy, channel)
+        if obj == None:
+            continue
 
         apply_func(obj, channel)
 
@@ -99,6 +103,8 @@ def process_channels(hierarchy, channels, rig, apply_func):
 def process_motion_channels(hierarchy, channels, rig):
     for channel in channels:
         obj = get_bone(rig, hierarchy, channel)
+        if obj == None:
+            continue
 
         if channel.delta_type == 0:
             apply_motion_channel_time_coded(obj, channel)

--- a/io_mesh_w3d/common/utils/animation_import.py
+++ b/io_mesh_w3d/common/utils/animation_import.py
@@ -4,6 +4,7 @@
 import bpy
 from io_mesh_w3d.w3d.adaptive_delta import decode
 from io_mesh_w3d.common.structs.animation import *
+from io_mesh_w3d.w3d.structs.compressed_animation import *
 
 
 def is_roottransform(channel):
@@ -115,17 +116,17 @@ def process_motion_channels(context, hierarchy, channels, rig):
             apply_adaptive_delta(obj, channel)
 
 
-def create_animation(context, rig, animation, hierarchy, compressed=False):
+def create_animation(context, rig, animation, hierarchy):
     if animation is None:
         return
 
     setup_animation(animation)
 
-    if not compressed:
-        process_channels(context, hierarchy, animation.channels, rig, apply_uncompressed)
-    else:
+    if isinstance(animation, CompressedAnimation):
         process_channels(context, hierarchy, animation.time_coded_channels, rig, apply_timecoded)
         process_channels(context, hierarchy, animation.adaptive_delta_channels, rig, apply_adaptive_delta)
         process_motion_channels(context, hierarchy, animation.motion_channels, rig)
+    else:
+        process_channels(context, hierarchy, animation.channels, rig, apply_uncompressed)
 
     bpy.context.scene.frame_set(0)

--- a/io_mesh_w3d/import_utils.py
+++ b/io_mesh_w3d/import_utils.py
@@ -57,4 +57,4 @@ def create_data(context, meshes, hlod=None, hierarchy=None, boxes=None, animatio
             create_mesh(context, mesh, collection)
 
     create_animation(context, rig, animation, hierarchy)
-    create_animation(context, rig, compressed_animation, hierarchy, compressed=True)
+    create_animation(context, rig, compressed_animation, hierarchy)

--- a/io_mesh_w3d/import_utils.py
+++ b/io_mesh_w3d/import_utils.py
@@ -56,5 +56,5 @@ def create_data(context, meshes, hlod=None, hierarchy=None, boxes=None, animatio
         for mesh in meshes:
             create_mesh(context, mesh, collection)
 
-    create_animation(rig, animation, hierarchy)
-    create_animation(rig, compressed_animation, hierarchy, compressed=True)
+    create_animation(context, rig, animation, hierarchy)
+    create_animation(context, rig, compressed_animation, hierarchy, compressed=True)

--- a/io_mesh_w3d/w3d/structs/compressed_animation.py
+++ b/io_mesh_w3d/w3d/structs/compressed_animation.py
@@ -337,6 +337,8 @@ class MotionChannel:
             num_time_codes=read_short(io_stream),
             pivot=read_short(io_stream))
 
+        print(result.type)
+
         if result.delta_type == 0:
             result.data = result.read_time_coded_data(io_stream)
         else:

--- a/io_mesh_w3d/w3d/structs/compressed_animation.py
+++ b/io_mesh_w3d/w3d/structs/compressed_animation.py
@@ -337,8 +337,6 @@ class MotionChannel:
             num_time_codes=read_short(io_stream),
             pivot=read_short(io_stream))
 
-        print(result.type)
-
         if result.delta_type == 0:
             result.data = result.read_time_coded_data(io_stream)
         else:

--- a/tests/common/cases/utils/test_animation_utils.py
+++ b/tests/common/cases/utils/test_animation_utils.py
@@ -11,6 +11,7 @@ from io_mesh_w3d.common.utils.animation_export import *
 from tests.common.helpers.mesh import *
 from tests.common.helpers.hierarchy import *
 from tests.common.helpers.animation import *
+from tests.w3d.helpers.compressed_animation import *
 from tests.utils import *
 
 
@@ -35,6 +36,22 @@ class TestAnimationUtils(TestCase):
         animation = get_animation()
 
         animation.channels = [get_animation_channel(type=CHANNEL_VIS, pivot=len(hierarchy.pivots))]
+
+        rig = get_or_create_skeleton(hierarchy, get_collection())
+
+        with (patch.object(self, 'warning')) as warning_func:
+            create_animation(self, rig, animation, hierarchy)
+            warning_func.assert_called_with(f'animation channel for bone with ID \'{len(hierarchy.pivots)}\' is invalid -> armature has only {len(hierarchy.pivots)} bones!')
+
+        ani = retrieve_animation(self, 'ani_name', hierarchy, rig, False)
+
+        self.assertEqual(0, len(ani.channels))
+
+    def test_user_is_notified_if_animation_contains_channels_for_nonexisting_bones_compressed(self):
+        hierarchy = get_hierarchy()
+        animation = get_compressed_animation_empty()
+
+        animation.motion_channels = [get_motion_channel(0, 0, 22, pivot=len(hierarchy.pivots))]
 
         rig = get_or_create_skeleton(hierarchy, get_collection())
 

--- a/tests/w3d/helpers/compressed_animation.py
+++ b/tests/w3d/helpers/compressed_animation.py
@@ -273,12 +273,12 @@ def compare_adaptive_delta_motion_animation_channels(
     compare_adaptive_delta_datas(self, expected.data, actual.data, type)
 
 
-def get_motion_channel(type, delta_type, num_time_codes=55):
+def get_motion_channel(type, delta_type, num_time_codes=55, pivot=3):
     channel = MotionChannel(
         delta_type=delta_type,
         type=type,
         num_time_codes=num_time_codes,
-        pivot=3,
+        pivot=pivot,
         data=[])
 
     if type == 6:

--- a/version_history.txt
+++ b/version_history.txt
@@ -1,4 +1,6 @@
 v0.6.6
+- inform user on animation import that armature might have been hidden due to visibility channels
+- do not crash on animation import if channels reference non existing bones but inform user instead
 
 v0.6.5 (26.3.21)
 - cancel export if a mesh and a bone share the same name and mesh is not configured properly


### PR DESCRIPTION
- some animations contain channels related to bone ids higher than the actual bone count of the skeleton -> ignore those on import
- some animations contain visibility cannels for the rootransform (bone id 0) this might result in a hidden armature object after import -> inform user