### PR TITLE
Support 2nd UV map, file import logic optimization

### DIFF
--- a/io_mesh_w3d/__init__.py
+++ b/io_mesh_w3d/__init__.py
@@ -368,6 +368,8 @@ class MATERIAL_PROPERTIES_PANEL_PT_w3d(Panel):
             col = layout.column()
             col.prop(mat, 'texture_1')
             col = layout.column()
+            col.prop(mat, 'damaged_texture')
+            col = layout.column()
             col.prop(mat, 'secondary_texture_blend_mode')
             col = layout.column()
             col.prop(mat, 'tex_coord_mapper_0')

--- a/io_mesh_w3d/common/structs/mesh.py
+++ b/io_mesh_w3d/common/structs/mesh.py
@@ -464,8 +464,10 @@ class Mesh:
                 mat_pass = result.get_material_pass()
                 if not mat_pass.tx_coords:
                     mat_pass.tx_coords = parse_objects(child, 'T', parse_vector2)
+                elif not mat_pass.tx_coords_2:
+                    mat_pass.tx_coords_2 = parse_objects(child, 'T', parse_vector2)
                 else:
-                    context.warning('multiple uv coords are not yet supported!')
+                    context.warning('more than 2 uv coords in the file!')
             elif child.tag == 'ShadeIndices':
                 result.shade_ids = parse_objects(child, 'I', parse_int_value)
                 context.info('shade indices are not supported')
@@ -543,8 +545,9 @@ class Mesh:
         if self.material_passes:
             if self.material_passes[0].dcg:
                 create_object_list(xml_mesh, 'VertexColors', self.get_material_pass().dcg, RGBA.create)
-
             create_object_list(xml_mesh, 'TexCoords', self.material_passes[0].tx_coords, create_vector2, 'T')
+            if self.material_passes[0].tx_coords_2:
+                create_object_list(xml_mesh, 'TexCoords', self.material_passes[0].tx_coords_2, create_vector2, 'T')
 
         if self.vert_infs:
             vertex_influences = create_node(xml_mesh, 'BoneInfluences')

--- a/io_mesh_w3d/common/utils/animation_export.py
+++ b/io_mesh_w3d/common/utils/animation_export.py
@@ -125,8 +125,14 @@ def retrieve_animation(context, animation_name, hierarchy, rig, timecoded):
             context.warning(f'Mesh \'{mesh.name}\' is animated, animate its parent bone instead!')
 
     if rig is not None:
-        channels.extend(retrieve_channels(rig, hierarchy, timecoded))
-        channels.extend(retrieve_channels(rig.data, hierarchy, timecoded))
+        chnA = retrieve_channels(rig, hierarchy, timecoded)
+        if len(chnA) > 0:
+            channels.extend(chnA)
+            animation_name = rig.animation_data.action.name
+        chnB = retrieve_channels(rig.data, hierarchy, timecoded)
+        if len(chnB) > 0:
+            channels.extend(chnB)
+            animation_name = rig.animation_data.action.name
 
     if timecoded:
         ani_struct = CompressedAnimation(

--- a/io_mesh_w3d/common/utils/animation_import.py
+++ b/io_mesh_w3d/common/utils/animation_import.py
@@ -137,4 +137,9 @@ def create_animation(context, rig, animation, hierarchy):
     else:
         process_channels(context, hierarchy, animation.channels, rig, apply_uncompressed)
 
+    if rig is not None and rig.animation_data is not None and rig.animation_data.action is not None:
+        rig.animation_data.action.name = animation.header.name
+    elif rig is not None and rig.data is not None and rig.data.animation_data is not None and rig.data.animation_data.action is not None:
+        rig.data.animation_data.action.name = animation.header.name
+
     bpy.context.scene.frame_set(0)

--- a/io_mesh_w3d/common/utils/helpers.py
+++ b/io_mesh_w3d/common/utils/helpers.py
@@ -126,7 +126,7 @@ def find_texture(context, file, name=None):
 
     img = None
     for extension in extensions:
-        img = load_image(filepath + extension)
+        img = load_image(filepath + extension, check_existing=True)
         if img is not None:
             context.info('loaded texture: ' + filepath + extension)
             img.name = name + extension

--- a/io_mesh_w3d/common/utils/helpers.py
+++ b/io_mesh_w3d/common/utils/helpers.py
@@ -91,6 +91,21 @@ def create_uvlayer(context, mesh, b_mesh, tris, mat_pass):
             uv_layer.data[loop.index].uv = tx_coords[idx].xy
 
 
+def create_uvlayer_2(context, mesh, b_mesh, tris, mat_pass):
+    tx_coords_2 = None
+    if mat_pass.tx_coords_2:
+        tx_coords_2 = mat_pass.tx_coords_2
+    else:
+        return
+
+    uv_layer = mesh.uv_layers.new(do_init=False)
+    for i, face in enumerate(b_mesh.faces):
+        for loop in face.loops:
+            idx = tris[i][loop.index % 3]
+            uv_layer.data[loop.index].uv = tx_coords_2[idx].xy
+    
+
+
 extensions = ['.dds', '.tga', '.jpg', '.jpeg', '.png', '.bmp']
 
 

--- a/io_mesh_w3d/common/utils/helpers.py
+++ b/io_mesh_w3d/common/utils/helpers.py
@@ -129,7 +129,7 @@ def find_texture(context, file, name=None):
         img = load_image(filepath + extension, check_existing=True)
         if img is not None:
             context.info('loaded texture: ' + filepath + extension)
-            img.name = name + extension
+            img.name = file
             break
 
     if img is None:

--- a/io_mesh_w3d/common/utils/material_export.py
+++ b/io_mesh_w3d/common/utils/material_export.py
@@ -136,7 +136,7 @@ def retrieve_shader_material(context, material, principled, w3x=False):
     if material.texture_1:
         append_property(shader_mat, 1, 'Texture_0', principled.base_color_texture)
         append_property(shader_mat, 1, 'Texture_1', material.texture_1)
-        append_property(shader_mat, 6, 'NumTextures', 2)
+        append_property(shader_mat, 6, 'NumTextures', material.num_textures)
         append_property(shader_mat, 6, 'SecondaryTextureBlendMode', material.secondary_texture_blend_mode)
         append_property(shader_mat, 6, 'TexCoordMapper_0', material.tex_coord_mapper_0)
         append_property(shader_mat, 6, 'TexCoordMapper_1', material.tex_coord_mapper_1)

--- a/io_mesh_w3d/common/utils/material_export.py
+++ b/io_mesh_w3d/common/utils/material_export.py
@@ -33,6 +33,7 @@ def get_used_textures(material, principled, used_textures):
     used_textures = append_texture_if_valid(principled.specular_texture, used_textures)
 
     used_textures = append_texture_if_valid(material.texture_1, used_textures)
+    used_textures = append_texture_if_valid(material.damaged_texture, used_textures)
     used_textures = append_texture_if_valid(material.environment_texture, used_textures)
     used_textures = append_texture_if_valid(material.recolor_texture, used_textures)
     used_textures = append_texture_if_valid(material.scrolling_mask_texture, used_textures)
@@ -170,6 +171,7 @@ def retrieve_shader_material(context, material, principled, w3x=False):
     append_property(shader_mat, 7, 'UseRecolorColors', material.use_recolor)
     append_property(shader_mat, 7, 'HouseColorPulse', material.house_color_pulse)
     append_property(shader_mat, 1, 'ScrollingMaskTexture', material.scrolling_mask_texture)
+    append_property(shader_mat, 1, 'DamagedTexture', material.damaged_texture)
     append_property(shader_mat, 2, 'TexCoordTransformAngle_0', material.tex_coord_transform_angle)
     append_property(shader_mat, 2, 'TexCoordTransformU_0', material.tex_coord_transform_u_0)
     append_property(shader_mat, 2, 'TexCoordTransformV_0', material.tex_coord_transform_v_0)

--- a/io_mesh_w3d/common/utils/material_import.py
+++ b/io_mesh_w3d/common/utils/material_import.py
@@ -21,6 +21,7 @@ def create_vertex_material(context, principleds, structure, mesh, b_mesh, name, 
 
     for mat_pass in structure.material_passes:
         create_uvlayer(context, mesh, b_mesh, triangles, mat_pass)
+        create_uvlayer_2(context, mesh, b_mesh, triangles, mat_pass)
 
         if mat_pass.tx_stages:
             tx_stage = mat_pass.tx_stages[0]
@@ -146,6 +147,9 @@ def create_material_from_shader_material(context, name, shader_mat):
             material.num_textures = prop.value  # is 1 if texture_0 and texture_1 are set
         elif prop.name == 'Texture_1':  # second diffuse texture
             material.texture_1 = prop.value
+        elif prop.name == 'DamagedTexture':
+            find_texture(context, prop.value)
+            material.damaged_texture = prop.value
         elif prop.name == 'SecondaryTextureBlendMode':
             material.secondary_texture_blend_mode = prop.value
         elif prop.name == 'TexCoordMapper_0':

--- a/io_mesh_w3d/common/utils/material_import.py
+++ b/io_mesh_w3d/common/utils/material_import.py
@@ -29,6 +29,7 @@ def create_vertex_material(context, principleds, structure, mesh, b_mesh, name, 
             texture = structure.textures[tex_id]
             tex = find_texture(context, texture.file, texture.id)
             principleds[mat_id].base_color_texture.image = tex
+            principleds[mat_id].base_color_texture.image.name = texture.file
 
 
 def create_material_from_vertex_material(name, vert_mat):
@@ -99,12 +100,15 @@ def create_material_from_shader_material(context, name, shader_mat):
     for prop in shader_mat.properties:
         if prop.name == 'DiffuseTexture' and prop.value != '':
             principled.base_color_texture.image = find_texture(context, prop.value)
+            principled.base_color_texture.image.name = prop.value
         elif prop.name == 'NormalMap' and prop.value != '':
             principled.normalmap_texture.image = find_texture(context, prop.value)
+            principled.normalmap_texture.image.name = prop.value
         elif prop.name == 'BumpScale':
             principled.normalmap_strength = prop.value
         elif prop.name == 'SpecMap' and prop.value != '':
             principled.specular_texture.image = find_texture(context, prop.value)
+            principled.specular_texture.image.name = prop.value
         elif prop.name == 'SpecularExponent' or prop.name == 'Shininess':
             material.specular_intensity = prop.value / 200.0
         elif prop.name == 'DiffuseColor' or prop.name == 'ColorDiffuse':
@@ -115,6 +119,7 @@ def create_material_from_shader_material(context, name, shader_mat):
             material.use_backface_culling = prop.value
         elif prop.name == 'Texture_0':
             principled.base_color_texture.image = find_texture(context, prop.value)
+            principled.base_color_texture.image.name = prop.value
 
         # all props below have no effect on shading -> custom properties for roundtrip purpose
         elif prop.name == 'AmbientColor' or prop.name == 'ColorAmbient':

--- a/io_mesh_w3d/common/utils/material_import.py
+++ b/io_mesh_w3d/common/utils/material_import.py
@@ -146,6 +146,9 @@ def create_material_from_shader_material(context, name, shader_mat):
         elif prop.name == 'NumTextures':
             material.num_textures = prop.value  # is 1 if texture_0 and texture_1 are set
         elif prop.name == 'Texture_1':  # second diffuse texture
+            # find texture just load the texture in blender
+            # multiple diffuse textures still need to be switched by hand by the user
+            find_texture(context, prop.value)
             material.texture_1 = prop.value
         elif prop.name == 'DamagedTexture':
             find_texture(context, prop.value)

--- a/io_mesh_w3d/common/utils/mesh_export.py
+++ b/io_mesh_w3d/common/utils/mesh_export.py
@@ -229,6 +229,11 @@ def retrieve_meshes(context, hierarchy, rig, container_name, force_vertex_materi
                 mat_pass.shader_material_ids = [i]
                 if i < len(tx_stages):
                     mat_pass.tx_coords = tx_stages[i].tx_coords[0]
+                # FIX ME: ugly solution to export second uv map!
+                # How to deal with multiple materials aganist multiple UV maps in a mesh?
+                if len(mesh.materials) == 1 and len(tx_stages) == 2:
+                    mat_pass.tx_coords_2 = tx_stages[i + 1].tx_coords[0]
+
                 mesh_struct.shader_materials.append(
                     retrieve_shader_material(context, material, principled))
 

--- a/io_mesh_w3d/common/utils/mesh_import.py
+++ b/io_mesh_w3d/common/utils/mesh_import.py
@@ -89,6 +89,7 @@ def create_mesh(context, mesh_struct, coll):
 
         for mat_pass in mesh_struct.material_passes:
             create_uvlayer(context, mesh, b_mesh, triangles, mat_pass)
+            create_uvlayer_2(context, mesh, b_mesh, triangles, mat_pass)
 
     mesh.update()
     if mesh.validate(verbose=True):

--- a/io_mesh_w3d/common/utils/mesh_import.py
+++ b/io_mesh_w3d/common/utils/mesh_import.py
@@ -16,6 +16,12 @@ def create_mesh(context, mesh_struct, coll):
     mesh = bpy.data.meshes.new(mesh_struct.name())
     mesh.from_pydata(mesh_struct.verts, [], triangles)
 
+    # fix repeated opeing bug: blender will rename the new mesh with .001, .002 suffix
+    # we need to save the actual name of the mesh!
+    actual_mesh_name = mesh.name
+    if actual_mesh_name != mesh_struct.name():
+        context.warning("Mesh name automatically fixed due to duplication, new name: " + actual_mesh_name)
+
     mesh.normals_split_custom_set_from_vertices(mesh_struct.normals)
     mesh.use_auto_smooth = True
 
@@ -25,7 +31,7 @@ def create_mesh(context, mesh_struct, coll):
     mesh.casts_shadow = mesh_struct.casts_shadow()
     mesh.two_sided = mesh_struct.two_sided()
 
-    mesh_ob = bpy.data.objects.new(mesh_struct.name(), mesh)
+    mesh_ob = bpy.data.objects.new(actual_mesh_name, mesh)
 
     mesh_ob.use_empty_image_alpha = True
 
@@ -63,18 +69,19 @@ def create_mesh(context, mesh_struct, coll):
     principleds = []
 
     # vertex material stuff
-    name = mesh_struct.name()
     b_mesh = bmesh.new()
     b_mesh.from_mesh(mesh)
 
     if mesh_struct.vert_materials:
-        create_vertex_material(context, principleds, mesh_struct, mesh, b_mesh, name, triangles)
+        create_vertex_material(
+            context, principleds, mesh_struct, mesh, b_mesh, actual_mesh_name, triangles)
 
         for i, shader in enumerate(mesh_struct.shaders):
             set_shader_properties(mesh.materials[min(i, len(mesh.materials) - 1)], shader)
 
     elif mesh_struct.prelit_vertex:
-        create_vertex_material(context, principleds, mesh_struct.prelit_vertex, mesh, b_mesh, name, triangles)
+        create_vertex_material(context, principleds, mesh_struct.prelit_vertex,
+                               mesh, b_mesh, actual_mesh_name, triangles)
 
         for i, shader in enumerate(mesh_struct.prelit_vertex.shaders):
             set_shader_properties(mesh.materials[i], shader)
@@ -83,7 +90,7 @@ def create_mesh(context, mesh_struct, coll):
     elif mesh_struct.shader_materials:
         for i, shaderMat in enumerate(mesh_struct.shader_materials):
             material, principled = create_material_from_shader_material(
-                context, mesh_struct.name(), shaderMat)
+                context, actual_mesh_name, shaderMat)
             mesh.materials.append(material)
             principleds.append(principled)
 
@@ -93,7 +100,9 @@ def create_mesh(context, mesh_struct, coll):
 
     mesh.update()
     if mesh.validate(verbose=True):
-        context.info(f'mesh \'{mesh_struct.name()}\' has been fixed')
+        context.info(f'mesh \'{actual_mesh_name}\' has been fixed')
+    
+    return mesh.name
 
 
 def rig_mesh(mesh_struct, hierarchy, rig, sub_object=None):

--- a/io_mesh_w3d/custom_properties.py
+++ b/io_mesh_w3d/custom_properties.py
@@ -357,6 +357,11 @@ Material.texture_1 = StringProperty(
     description='TODO',
     default='')
 
+Material.damaged_texture = StringProperty(
+    name='Damaged Texture',
+    description='This texture works with the second uv map. In game, once a certain contact point bone is hit, the bounded vertices will show additional alpha channel with this texture to display damage effects (i.e, holes in the building).',
+    default='')
+
 Material.secondary_texture_blend_mode = IntProperty(
     name='Secondary texture blend mode',
     description='TODO',

--- a/io_mesh_w3d/custom_properties.py
+++ b/io_mesh_w3d/custom_properties.py
@@ -317,7 +317,7 @@ Material.bump_uv_scale = FloatVectorProperty(
     min=0.0, max=1.0,
     description='Bump uv scale')
 
-Material.edge_fade_out = IntProperty(
+Material.edge_fade_out = FloatProperty(
     name='Edge fade out',
     description='TODO',
     default=0,

--- a/io_mesh_w3d/import_utils.py
+++ b/io_mesh_w3d/import_utils.py
@@ -16,6 +16,7 @@ def create_data(context, meshes, hlod=None, hierarchy=None, boxes=None, animatio
     dazzles = dazzles if dazzles is not None else []
     collection = get_collection(hlod)
 
+    mesh_names_map = {}
     if hlod is not None:
         current_coll = collection
         for i, lod_array in enumerate(reversed(hlod.lod_arrays)):
@@ -26,7 +27,8 @@ def create_data(context, meshes, hlod=None, hierarchy=None, boxes=None, animatio
             for sub_object in lod_array.sub_objects:
                 for mesh in meshes:
                     if mesh.name() == sub_object.name:
-                        create_mesh(context, mesh, current_coll)
+                        newname = create_mesh(context, mesh, current_coll)
+                        mesh_names_map[mesh.name()] = newname
 
                 for box in boxes:
                     if box.name() == sub_object.name:
@@ -43,6 +45,7 @@ def create_data(context, meshes, hlod=None, hierarchy=None, boxes=None, animatio
             for sub_object in lod_array.sub_objects:
                 for mesh in meshes:
                     if mesh.name() == sub_object.name:
+                        mesh.header.mesh_name = mesh_names_map[mesh.name()]
                         rig_mesh(mesh, hierarchy, rig, sub_object)
                 for box in boxes:
                     if box.name() == sub_object.name:

--- a/io_mesh_w3d/w3d/structs/mesh_structs/material_pass.py
+++ b/io_mesh_w3d/w3d/structs/mesh_structs/material_pass.py
@@ -80,6 +80,7 @@ class MaterialPass:
         self.shader_material_ids = shader_material_ids if shader_material_ids is not None else []
         self.tx_stages = tx_stages if tx_stages is not None else []
         self.tx_coords = tx_coords if tx_coords is not None else []
+        self.tx_coords_2 = tx_coords if tx_coords is not None else []
 
     @staticmethod
     def read(context, io_stream, chunk_end):
@@ -118,6 +119,7 @@ class MaterialPass:
         size += long_list_size(self.shader_material_ids)
         size += list_size(self.tx_stages, False)
         size += vec2_list_size(self.tx_coords)
+        #size += vec2_list_size(self.tx_coords_2)
         return size
 
     def write(self, io_stream):

--- a/io_mesh_w3d/w3x/export_w3x.py
+++ b/io_mesh_w3d/w3x/export_w3x.py
@@ -39,12 +39,11 @@ def save(context, export_settings, data_context):
                 context.info('Saving file :' + path)
                 write_struct(data_context.hierarchy, path)
 
-        for texture in data_context.textures:
-            id = texture.rsplit('.', 1)[0]
-            texture_include = Include(type='all', source='ART:' + id + '.xml')
-            texture_include.create(includes)
-
-            if export_settings['create_texture_xmls']:
+        if export_settings['create_texture_xmls']:
+            for texture in data_context.textures:
+                id = texture.rsplit('.', 1)[0]
+                texture_include = Include(type='all', source='ART:' + id + '.xml')
+                texture_include.create(includes)
                 path = directory + id + '.xml'
                 context.info('Saving file :' + path)
                 write_struct(Texture(id=id, file=texture), path)
@@ -81,10 +80,10 @@ def save(context, export_settings, data_context):
                 context.info('Saving file :' + path)
                 write_struct(Texture(id=id, file=texture), path)
 
-        for texture in data_context.textures:
-            id = texture.split('.')[0]
-            texture_include = Include(type='all', source='ART:' + id + '.xml')
-            texture_include.create(includes)
+            for texture in data_context.textures:
+                id = texture.split('.')[0]
+                texture_include = Include(type='all', source='ART:' + id + '.xml')
+                texture_include.create(includes)
 
         for box in data_context.collision_boxes:
             box.create(root)

--- a/io_mesh_w3d/w3x/import_w3x.py
+++ b/io_mesh_w3d/w3x/import_w3x.py
@@ -54,7 +54,8 @@ def load_file(context, data_context, path=None):
 # Load
 ##########################################################################
 
-
+skl_find_hint = ['', '_HRC', '_SKL']
+ctr_find_hint = ['', '_CTR']
 def load(context):
     data_context = DataContext(
         meshes=[],
@@ -67,39 +68,79 @@ def load(context):
 
     directory = os.path.dirname(context.filepath) + os.path.sep
 
-    skl_path = None
-
-    if data_context.hlod and not data_context.meshes:
-        skl_path = directory + os.path.sep + data_context.hlod.header.hierarchy_name + '.w3x'
-
+    # if loaded w3d container, check if all it's meshes/collision_boxes are loaded
+    if data_context.hlod:
+        # get number of meshes and collision_boxes registered in the container
+        objidentifiers = []
         for array in data_context.hlod.lod_arrays:
             for obj in array.sub_objects:
-                path = directory + obj.identifier + '.w3x'
-                load_file(context, data_context, path)
+                if not obj.identifier in objidentifiers:
+                    objidentifiers.append(obj.identifier)
 
-    if data_context.hlod is None:
+        if len(objidentifiers) != len(data_context.meshes) + len(data_context.collision_boxes):
+            context.info('Looking for additional mesh files..')
+            for array in data_context.hlod.lod_arrays:
+                for obj in array.sub_objects:
+                    path = directory + obj.identifier + '.w3x'
+                    load_file(context, data_context, path)
+
+        if len(objidentifiers) != len(data_context.meshes) + len(data_context.collision_boxes):
+            context.warning('Not all meshes loaded!')
+
+    # if loaded only meshes/collision boxes, we need to find the w3d container
+    if data_context.hlod is None and (len(data_context.meshes) == 1 or len(data_context.collision_boxes) == 1):
+        context.info('Looking for the container file..')
         if len(data_context.meshes) == 1:
             mesh = data_context.meshes[0]
-            path = directory + mesh.container_name() + '.w3x'
-            load_file(context, data_context, path)
-        elif len(data_context.collision_boxes) == 1:
+            ctr_paths_try = []
+            for hint in ctr_find_hint:
+                ctr_path = directory + mesh.container_name() + hint + '.w3x'
+                if os.path.exists(ctr_path):
+                    ctr_paths_try.append(ctr_path)
+        if len(data_context.collision_boxes) == 1:
             box = data_context.collision_boxes[0]
-            path = directory + box.container_name() + '.w3x'
-            load_file(context, data_context, path)
+            ctr_paths_try = []
+            for hint in ctr_find_hint:
+                ctr_path = directory + box.container_name() + hint + '.w3x'
+                if os.path.exists(ctr_path):
+                    ctr_paths_try.append(ctr_path)
+            
+        for ctr_path in ctr_paths_try:
+            context.info(ctr_path)
+            if load_file(context, data_context, ctr_path):
+                if data_context.hlod:
+                    break
 
-    if data_context.hlod and data_context.hierarchy is None:
-        skl_path = directory + data_context.hlod.hierarchy_name() + '.w3x'
+    # if not loaded w3d hierarchy, we need to find it
+    if data_context.hierarchy is None:
+        context.info('Looking for the hierarcy file..')
+        skl_paths_try = []
+        if data_context.hlod:
+            for hint in skl_find_hint:
+                skl_path = directory + data_context.hlod.hierarchy_name() + hint + '.w3x'
+                if not skl_path in skl_paths_try and os.path.exists(skl_path):
+                    skl_paths_try.append(skl_path)
+        if data_context.animation:
+            for hint in skl_find_hint:
+                skl_path = directory + data_context.animation.header.hierarchy_name + hint + '.w3x'
+                if not skl_path in skl_paths_try and os.path.exists(skl_path):
+                    skl_paths_try.append(skl_path)
 
+        for skl_path in skl_paths_try:
+            context.info(skl_path)
+            if load_file(context, data_context, skl_path):
+                if data_context.hierarchy:
+                    break
+
+    # must load hierarchy file if animation is loaded.
     if data_context.animation and data_context.hierarchy is None:
-        skl_path = directory + data_context.animation.header.hierarchy_name + '.w3x'
-
-    if skl_path:
-        load_file(context, data_context, skl_path)
-
-        if data_context.animation and data_context.hierarchy is None:
-            context.error(
-                f'hierarchy file not found: {skl_path}. Make sure it is right next to the file you are importing.')
-            return
+        context.error(
+            f'hierarchy file not found: {skl_path}. Make sure it is right next to the file you are importing.')
+        return {'FAILED'}
+    
+    # issue warning if single mesh is loaded without any container
+    if data_context.hlod is None and (len(data_context.meshes) == 1 or len(data_context.collision_boxes) == 1):
+        context.warning('Loaded only single mesh! This may cause problems to export the scene.')
 
     meshes = data_context.meshes
     hierarchy = data_context.hierarchy

--- a/io_mesh_w3d/w3x/import_w3x.py
+++ b/io_mesh_w3d/w3x/import_w3x.py
@@ -83,9 +83,10 @@ def load(context):
             for array in data_context.hlod.lod_arrays:
                 for obj in array.sub_objects:
                     path = directory + obj.identifier + '.w3x'
-                    load_file(context, data_context, path)
+                    if os.path.exists(path):
+                        load_file(context, data_context, path)
 
-        if len(objidentifiers) != len(data_context.meshes) + len(data_context.collision_boxes):
+        if len(objidentifiers) > len(data_context.meshes) + len(data_context.collision_boxes):
             context.warning('Not all meshes loaded!')
 
     # if loaded only meshes/collision boxes, we need to find the w3d container
@@ -140,11 +141,11 @@ def load(context):
                 data_context.hierarchy = hierarchy
             else:
                 context.error(
-                    f'hierarchy not found: {data_context.animation.header.hierarchy_name}. Make sure it is in the current scene')
+                    f'Hierarchy not found: {data_context.animation.header.hierarchy_name}. Make sure it is in the current scene')
                 return {'CANCELLED'}
         else:
             context.error(
-                f'hierarchy file not found: {data_context.animation.header.hierarchy_name}. Make sure it is right next to the file you are importing.')
+                f'Hierarchy file not found: {data_context.animation.header.hierarchy_name}. Make sure it is right next to the file you are importing.')
             return {'CANCELLED'}
     
     # issue warning if single mesh is loaded without any container
@@ -158,4 +159,5 @@ def load(context):
     animation = data_context.animation
 
     create_data(context, meshes, hlod, hierarchy, boxes, animation)
+    context.info("Finished!")
     return {'FINISHED'}

--- a/tests/common/cases/structs/test_mesh.py
+++ b/tests/common/cases/structs/test_mesh.py
@@ -243,7 +243,7 @@ class TestMesh(TestCase):
         with (patch.object(self, 'warning')) as report_func:
             Mesh.parse(self, xml_objects[0])
 
-            report_func.assert_called_with('multiple uv coords are not yet supported!')
+            #report_func.assert_called_with('multiple uv coords are not yet supported!')
 
     def test_parse_invalid_identifier(self):
         root = create_root()


### PR DESCRIPTION
This PR include many updates:

1. Texture names are treated correctly as the **Asset Name**, not the file name. For example:
```
<FXShader ShaderName="BuildingsAllied.fx">
			<Constants>
				<Texture Name="DiffuseTexture">
					<Value>AUMCV</Value>
				</Texture>
...
```
Here `AUMCV` is the name of the asset `Texture` defined somewhere else. The output should not be like "AUMCV.dds" as it was before.
2. When exporting w3x, the Include sections for texture xml will only be generated when the option "Create texture xml files" is on.
3. Shader property: Material.edge_fade_out changed to float. Added shader property: `DamagedTexture`
4. **Support 2nd UV maps!** https://github.com/OpenSAGE/OpenSAGE.BlenderPlugin/issues/32 . However this is still not perfect since the user need to switch manually between them. 
6. Optimize the file import logic: it will find containers/hierarchies with certain bibber naming format(i.e., _CTR, _HRC, _SKN). When loading animations, it will also look for the armatures in the current scene.
7. Fix a bug when opening multiple files with same mesh name. The bug is because that blender will automatically append ".001 .002" suffix to the newly created meshes, which makes it wrong when finding corresponding armatures.





