### PR TITLE
Added support for Blender 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Version History
 
+## v0.7.4
+
+* adapt to API changes in Blender 5.2
+* the add-on can now be installed as an extension (Blender 4.2+), the release archive works for both
+  the extension and the legacy add-on install
+* replaced deprecated API usage: `Material.blend_method` -> `Material.surface_render_method`,
+  `Material.show_transparent_back` -> `Material.use_transparency_overlap`, `Material.use_nodes`,
+  `Mesh.vertex_colors` -> `Mesh.color_attributes` and `MeshUVLoopLayer.data` -> `MeshUVLoopLayer.uv`
+* transparency of imported materials is applied again in EEVEE Next (Blender 4.2+)
+* Bugfix: import no longer fails on Blender 4.1 (`Mesh.use_auto_smooth` was removed there, not in 4.2)
+* Bugfix: do not rely on the deprecated truth value of xml elements when writing w3x files
+
 ## v0.7.3
 
 * adapt to API changes in Blender 5.1+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ format used in Command & Conquer™: Generals and other RTS titles from Westwood
 
 Please see [Installing the plugin](https://github.com/OpenSAGE/OpenSAGE.BlenderPlugin/wiki/Installing-the-Plugin)
 
+Supported Blender versions are 2.93 up to 5.2. On Blender 4.2 and newer the released `io_mesh_w3d.zip`
+can be dropped into Blender to install it as an extension, older versions install it as a legacy add-on
+via *Edit > Preferences > Add-ons > Install*.
+
 ## Setting up for development
 
 Please see [Setting up for development](https://github.com/OpenSAGE/OpenSAGE.BlenderPlugin/wiki/Development-Setup)

--- a/io_mesh_w3d/__init__.py
+++ b/io_mesh_w3d/__init__.py
@@ -4,20 +4,25 @@
 import bpy
 from bpy.types import Panel
 from bpy_extras.io_utils import ImportHelper, ExportHelper
-from io_mesh_w3d.utils import ReportHelper
-from io_mesh_w3d.export_utils import save_data
-from io_mesh_w3d.custom_properties import *
-from io_mesh_w3d.geometry_export import *
-from io_mesh_w3d.bone_volume_export import *
+from .utils import ReportHelper
+from .export_utils import save_data
+from .custom_properties import *
+from .geometry_export import *
+from .bone_volume_export import *
 
-from io_mesh_w3d.blender_addon_updater import addon_updater_ops
+from .blender_addon_updater import addon_updater_ops
 
-VERSION = (0, 7, 3)
+VERSION = (0, 7, 4)
 
+# add-ons installed through the extension system (Blender 4.2+) live in the
+# 'bl_ext' package and are kept up to date by Blender itself
+IS_EXTENSION = (__package__ or '').startswith('bl_ext.')
+
+# 'bl_info' is only used for legacy installs, extensions are described by 'blender_manifest.toml'
 bl_info = {
     'name': 'Import/Export Westwood W3D Format (.w3d/.w3x)',
     'author': 'OpenSage Developers',
-    'version': (0, 7, 3),
+    'version': (0, 7, 4),
     "blender": (2, 90, 0),
     'location': 'File > Import/Export > Westwood W3D (.w3d/.w3x)',
     'description': 'Import or Export the Westwood W3D-Format (.w3d/.w3x)',
@@ -298,7 +303,11 @@ class MATERIAL_PROPERTIES_PANEL_PT_w3d(Panel):
         col = layout.column()
         col.prop(mat, 'surface_type')
         col = layout.column()
-        col.prop(mat, 'blend_method')
+        # 'blend_method' is deprecated since Blender 4.2, EEVEE Next uses 'surface_render_method'
+        if bpy.app.version < (4, 2, 0):
+            col.prop(mat, 'blend_method')
+        else:
+            col.prop(mat, 'surface_render_method')
         col = layout.column()
         col.prop(mat, 'ambient')
 
@@ -509,26 +518,35 @@ CLASSES = (
     MATERIAL_PROPERTIES_PANEL_PT_w3d,
     ExportGeometryData,
     ExportBoneVolumeData,
-    TOOLS_PANEL_PT_w3d,
+    TOOLS_PANEL_PT_w3d
+)
+
+# the bundled updater would overwrite the add-on behind Blender's back,
+# extensions are updated through their repository instead
+UPDATER_CLASSES = (
     DemoPreferences,
     OBJECT_PT_DemoUpdaterPanel
 )
 
 
 def register():
-    addon_updater_ops._package = 'io_mesh_w3d'
-    addon_updater_ops.updater.addon = 'io_mesh_w3d'
-    addon_updater_ops.updater.user = "OpenSAGE"
-    addon_updater_ops.updater.repo = "OpenSAGE.BlenderPlugin"
-    addon_updater_ops.updater.website = "https://github.com/OpenSAGE/OpenSAGE.BlenderPlugin"
-    addon_updater_ops.updater.subfolder_path = "io_mesh_w3d"
-    addon_updater_ops.updater.include_branch_list = ['master']
-    addon_updater_ops.updater.verbose = False
-
-    addon_updater_ops.register(bl_info)
-
     for class_ in CLASSES:
         bpy.utils.register_class(class_)
+
+    if not IS_EXTENSION:
+        addon_updater_ops._package = 'io_mesh_w3d'
+        addon_updater_ops.updater.addon = 'io_mesh_w3d'
+        addon_updater_ops.updater.user = "OpenSAGE"
+        addon_updater_ops.updater.repo = "OpenSAGE.BlenderPlugin"
+        addon_updater_ops.updater.website = "https://github.com/OpenSAGE/OpenSAGE.BlenderPlugin"
+        addon_updater_ops.updater.subfolder_path = "io_mesh_w3d"
+        addon_updater_ops.updater.include_branch_list = ['master']
+        addon_updater_ops.updater.verbose = False
+
+        addon_updater_ops.register(bl_info)
+
+        for class_ in UPDATER_CLASSES:
+            bpy.utils.register_class(class_)
 
     Material.shader = PointerProperty(type=ShaderProperties)
 
@@ -537,7 +555,11 @@ def register():
 
 
 def unregister():
-    addon_updater_ops.unregister()
+    if not IS_EXTENSION:
+        addon_updater_ops.unregister()
+
+        for class_ in reversed(UPDATER_CLASSES):
+            bpy.utils.unregister_class(class_)
 
     for class_ in reversed(CLASSES):
         bpy.utils.unregister_class(class_)

--- a/io_mesh_w3d/blender_manifest.toml
+++ b/io_mesh_w3d/blender_manifest.toml
@@ -1,0 +1,36 @@
+schema_version = "1.0.0"
+
+id = "io_mesh_w3d"
+version = "0.7.4"
+name = "Import/Export Westwood W3D Format (.w3d/.w3x)"
+tagline = "Import or export the Westwood W3D format used by SAGE games"
+maintainer = "OpenSage Developers <https://github.com/OpenSAGE>"
+type = "add-on"
+
+website = "https://github.com/OpenSAGE/OpenSAGE.BlenderPlugin"
+
+tags = ["Import-Export"]
+
+# The extension system was introduced in Blender 4.2, older versions install
+# this add-on through the legacy 'bl_info' path instead.
+blender_version_min = "4.2.0"
+
+license = [
+  "SPDX:LGPL-3.0-or-later",
+]
+
+[permissions]
+files = "Import and export W3D/W3X models, animations and textures"
+network = "Check github for new releases of this add-on"
+
+[build]
+paths_exclude_pattern = [
+  "__pycache__/",
+  "/.git/",
+  "/*.zip",
+  "/blender_addon_updater/.git/",
+  "/blender_addon_updater/tests/",
+  "/blender_addon_updater/images/",
+  "*_updater_status.json",
+  "/blender_addon_updater/io_mesh_w3d.blender_addon_updater_updater/",
+]

--- a/io_mesh_w3d/bone_volume_export.py
+++ b/io_mesh_w3d/bone_volume_export.py
@@ -2,10 +2,10 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 import bpy
-from io_mesh_w3d.utils import ReportHelper
+from .utils import ReportHelper
 from bpy_extras.io_utils import ExportHelper
-from io_mesh_w3d.w3x.io_xml import *
-from io_mesh_w3d.common.utils.helpers import *
+from .w3x.io_xml import *
+from .common.utils.helpers import *
 
 
 def format_str(value):

--- a/io_mesh_w3d/common/structs/animation.py
+++ b/io_mesh_w3d/common/structs/animation.py
@@ -1,9 +1,9 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.structs.version import Version
-from io_mesh_w3d.w3d.utils.helpers import *
-from io_mesh_w3d.w3x.io_xml import *
+from ...w3d.structs.version import Version
+from ...w3d.utils.helpers import *
+from ...w3x.io_xml import *
 
 W3D_CHUNK_ANIMATION_HEADER = 0x00000201
 

--- a/io_mesh_w3d/common/structs/collision_box.py
+++ b/io_mesh_w3d/common/structs/collision_box.py
@@ -2,10 +2,10 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector
-from io_mesh_w3d.common.structs.rgba import RGBA
-from io_mesh_w3d.w3d.utils.helpers import *
-from io_mesh_w3d.w3d.structs.version import Version
-from io_mesh_w3d.w3x.io_xml import *
+from ...common.structs.rgba import RGBA
+from ...w3d.utils.helpers import *
+from ...w3d.structs.version import Version
+from ...w3x.io_xml import *
 
 W3D_CHUNK_BOX = 0x00000740
 ATTRIBUTE_MASK = 0xF

--- a/io_mesh_w3d/common/structs/hierarchy.py
+++ b/io_mesh_w3d/common/structs/hierarchy.py
@@ -2,9 +2,9 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector, Quaternion, Matrix
-from io_mesh_w3d.w3d.structs.version import Version
-from io_mesh_w3d.w3d.utils.helpers import *
-from io_mesh_w3d.w3x.io_xml import *
+from ...w3d.structs.version import Version
+from ...w3d.utils.helpers import *
+from ...w3x.io_xml import *
 
 W3D_CHUNK_HIERARCHY_HEADER = 0x00000101
 

--- a/io_mesh_w3d/common/structs/hlod.py
+++ b/io_mesh_w3d/common/structs/hlod.py
@@ -1,9 +1,9 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.structs.version import Version
-from io_mesh_w3d.w3d.utils.helpers import *
-from io_mesh_w3d.w3x.io_xml import *
+from ...w3d.structs.version import Version
+from ...w3d.utils.helpers import *
+from ...w3x.io_xml import *
 
 W3D_CHUNK_HLOD_HEADER = 0x00000701
 

--- a/io_mesh_w3d/common/structs/mesh.py
+++ b/io_mesh_w3d/common/structs/mesh.py
@@ -2,14 +2,14 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector
-from io_mesh_w3d.common.structs.mesh_structs.aabbtree import *
-from io_mesh_w3d.common.structs.mesh_structs.shader_material import *
-from io_mesh_w3d.common.structs.mesh_structs.triangle import *
-from io_mesh_w3d.common.structs.mesh_structs.vertex_influence import *
-from io_mesh_w3d.w3d.structs.mesh_structs.prelit import *
-from io_mesh_w3d.w3d.structs.version import Version
-from io_mesh_w3d.w3x.structs.mesh_structs.bounding_box import *
-from io_mesh_w3d.w3x.structs.mesh_structs.bounding_sphere import *
+from ...common.structs.mesh_structs.aabbtree import *
+from ...common.structs.mesh_structs.shader_material import *
+from ...common.structs.mesh_structs.triangle import *
+from ...common.structs.mesh_structs.vertex_influence import *
+from ...w3d.structs.mesh_structs.prelit import *
+from ...w3d.structs.version import Version
+from ...w3x.structs.mesh_structs.bounding_box import *
+from ...w3x.structs.mesh_structs.bounding_sphere import *
 
 W3D_CHUNK_MESH_HEADER = 0x0000001F
 

--- a/io_mesh_w3d/common/structs/mesh_structs/aabbtree.py
+++ b/io_mesh_w3d/common/structs/mesh_structs/aabbtree.py
@@ -2,9 +2,9 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector
-from io_mesh_w3d.w3d.utils.helpers import *
-from io_mesh_w3d.w3d.io_binary import *
-from io_mesh_w3d.w3x.io_xml import *
+from ....w3d.utils.helpers import *
+from ....w3d.io_binary import *
+from ....w3x.io_xml import *
 
 W3D_CHUNK_AABBTREE_HEADER = 0x00000091
 

--- a/io_mesh_w3d/common/structs/mesh_structs/shader_material.py
+++ b/io_mesh_w3d/common/structs/mesh_structs/shader_material.py
@@ -2,8 +2,8 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector
-from io_mesh_w3d.w3d.utils.helpers import *
-from io_mesh_w3d.w3x.io_xml import *
+from ....w3d.utils.helpers import *
+from ....w3x.io_xml import *
 
 W3D_CHUNK_SHADER_MATERIAL_HEADER = 0x52
 

--- a/io_mesh_w3d/common/structs/mesh_structs/texture.py
+++ b/io_mesh_w3d/common/structs/mesh_structs/texture.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.utils.helpers import *
-from io_mesh_w3d.w3x.io_xml import *
+from ....w3d.utils.helpers import *
+from ....w3x.io_xml import *
 
 W3D_CHUNK_TEXTURES = 0x00000030
 W3D_CHUNK_TEXTURE_INFO = 0x00000033

--- a/io_mesh_w3d/common/structs/mesh_structs/triangle.py
+++ b/io_mesh_w3d/common/structs/mesh_structs/triangle.py
@@ -2,8 +2,8 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector
-from io_mesh_w3d.w3d.io_binary import *
-from io_mesh_w3d.w3x.io_xml import *
+from ....w3d.io_binary import *
+from ....w3x.io_xml import *
 
 
 surface_types = [

--- a/io_mesh_w3d/common/structs/mesh_structs/vertex_influence.py
+++ b/io_mesh_w3d/common/structs/mesh_structs/vertex_influence.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.io_binary import *
-from io_mesh_w3d.w3x.io_xml import *
+from ....w3d.io_binary import *
+from ....w3x.io_xml import *
 
 
 class VertexInfluence:

--- a/io_mesh_w3d/common/structs/rgba.py
+++ b/io_mesh_w3d/common/structs/rgba.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.io_binary import *
-from io_mesh_w3d.w3x.io_xml import *
+from ...w3d.io_binary import *
+from ...w3x.io_xml import *
 
 
 class RGBA:

--- a/io_mesh_w3d/common/utils/animation_export.py
+++ b/io_mesh_w3d/common/utils/animation_export.py
@@ -3,9 +3,9 @@
 
 import bpy
 from mathutils import Quaternion
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.common.structs.animation import *
-from io_mesh_w3d.w3d.structs.compressed_animation import *
+from ...common.utils.helpers import *
+from ...common.structs.animation import *
+from ...w3d.structs.compressed_animation import *
 
 
 def is_translation(channel_type):

--- a/io_mesh_w3d/common/utils/animation_import.py
+++ b/io_mesh_w3d/common/utils/animation_import.py
@@ -2,9 +2,9 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 import bpy
-from io_mesh_w3d.w3d.adaptive_delta import decode
-from io_mesh_w3d.common.structs.animation import *
-from io_mesh_w3d.w3d.structs.compressed_animation import *
+from ...w3d.adaptive_delta import decode
+from ...common.structs.animation import *
+from ...w3d.structs.compressed_animation import *
 
 
 def is_roottransform(channel):

--- a/io_mesh_w3d/common/utils/box_export.py
+++ b/io_mesh_w3d/common/utils/box_export.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.common.structs.collision_box import *
+from ...common.utils.helpers import *
+from ...common.structs.collision_box import *
 
 
 def retrieve_boxes(container_name):

--- a/io_mesh_w3d/common/utils/box_import.py
+++ b/io_mesh_w3d/common/utils/box_import.py
@@ -2,8 +2,8 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 import bpy
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.common.structs.collision_box import *
+from ...common.utils.helpers import *
+from ...common.structs.collision_box import *
 
 
 def create_box(box, coll):

--- a/io_mesh_w3d/common/utils/helpers.py
+++ b/io_mesh_w3d/common/utils/helpers.py
@@ -59,6 +59,70 @@ def iter_action_fcurves(animation_data):
         yield from action.fcurves
 
 
+# 'Material.blend_method' is deprecated since Blender 4.2 and has no effect in EEVEE Next,
+# which uses 'Material.surface_render_method' instead
+SURFACE_RENDER_METHODS = {
+    'OPAQUE': 'DITHERED',
+    'CLIP': 'DITHERED',
+    'HASHED': 'DITHERED',
+    'BLEND': 'BLENDED'}
+
+
+def set_blend_method(material, blend_method):
+    if bpy.app.version < (4, 2, 0):
+        material.blend_method = blend_method
+        return
+    material.surface_render_method = SURFACE_RENDER_METHODS[blend_method]
+
+
+def enable_nodes(material):
+    # 'Material.use_nodes' is deprecated and gets removed in Blender 6.0,
+    # since Blender 5.0 materials always come with a node tree
+    if material.node_tree is None:
+        material.use_nodes = True
+
+
+def set_transparency_overlap(material, value):
+    # 'Material.show_transparent_back' is deprecated since Blender 4.2
+    if bpy.app.version < (4, 2, 0):
+        material.show_transparent_back = value
+        return
+    material.use_transparency_overlap = value
+
+
+def new_vertex_color_layer(mesh, name):
+    # 'Mesh.vertex_colors' is deprecated since Blender 3.2 in favour of color attributes
+    if bpy.app.version < (3, 2, 0):
+        return mesh.vertex_colors.new(name=name)
+    return mesh.color_attributes.new(name=name, type='BYTE_COLOR', domain='CORNER')
+
+
+def get_vertex_color_layers(mesh):
+    if bpy.app.version < (3, 2, 0):
+        return list(mesh.vertex_colors)
+    return [attribute for attribute in mesh.color_attributes if attribute.domain == 'CORNER']
+
+
+def set_uv(uv_layer, index, value):
+    # 'MeshUVLoopLayer.data' is deprecated since Blender 3.5 in favour of the 'uv' attribute
+    if bpy.app.version < (3, 5, 0):
+        uv_layer.data[index].uv = value
+        return
+    uv_layer.uv[index].vector = value
+
+
+def get_uv(uv_layer, index):
+    if bpy.app.version < (3, 5, 0):
+        return uv_layer.data[index].uv
+    return uv_layer.uv[index].vector
+
+
+def get_uv_count(uv_layer):
+    if bpy.app.version < (3, 5, 0):
+        return len(uv_layer.data)
+    return len(uv_layer.uv)
+
+
 def insensitive_path(path):
     # find the io_stream on unix
     directory = os.path.dirname(path)
@@ -123,7 +187,7 @@ def create_uvlayer(context, mesh, b_mesh, tris, mat_pass):
     for i, face in enumerate(b_mesh.faces):
         for loop in face.loops:
             idx = tris[i][loop.index % 3]
-            uv_layer.data[loop.index].uv = tx_coords[idx].xy
+            set_uv(uv_layer, loop.index, tx_coords[idx].xy)
 
 
 def create_uvlayer_2(context, mesh, b_mesh, tris, mat_pass):
@@ -138,7 +202,7 @@ def create_uvlayer_2(context, mesh, b_mesh, tris, mat_pass):
     for i, face in enumerate(b_mesh.faces):
         for loop in face.loops:
             idx = tris[i][loop.index % 3]
-            uv_layer.data[loop.index].uv = tx_coords_2[idx].xy
+            set_uv(uv_layer, loop.index, tx_coords_2[idx].xy)
 
 
 extensions = ['.dds', '.tga', '.jpg', '.jpeg', '.png', '.bmp']

--- a/io_mesh_w3d/common/utils/hierarchy_export.py
+++ b/io_mesh_w3d/common/utils/hierarchy_export.py
@@ -2,8 +2,8 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.common.structs.hierarchy import *
+from ...common.utils.helpers import *
+from ...common.structs.hierarchy import *
 
 
 pick_plane_names = ['PICK']

--- a/io_mesh_w3d/common/utils/hierarchy_import.py
+++ b/io_mesh_w3d/common/utils/hierarchy_import.py
@@ -3,8 +3,8 @@
 
 import bpy
 from mathutils import Vector, Quaternion, Matrix
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.common.utils.primitives import *
+from ...common.utils.helpers import *
+from ...common.utils.primitives import *
 
 
 def get_or_create_skeleton(hierarchy, coll):

--- a/io_mesh_w3d/common/utils/hlod_export.py
+++ b/io_mesh_w3d/common/utils/hlod_export.py
@@ -3,8 +3,8 @@
 
 import bpy
 
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.common.structs.hlod import *
+from ...common.utils.helpers import *
+from ...common.structs.hlod import *
 
 
 screen_sizes = [MAX_SCREEN_SIZE, 1.0, 0.3, 0.03]

--- a/io_mesh_w3d/common/utils/material_export.py
+++ b/io_mesh_w3d/common/utils/material_export.py
@@ -3,9 +3,9 @@
 
 import bpy
 from mathutils import Vector
-from io_mesh_w3d.w3d.structs.mesh_structs.shader import *
-from io_mesh_w3d.w3d.structs.mesh_structs.vertex_material import *
-from io_mesh_w3d.common.structs.mesh_structs.shader_material import *
+from ...w3d.structs.mesh_structs.shader import *
+from ...w3d.structs.mesh_structs.vertex_material import *
+from ...common.structs.mesh_structs.shader_material import *
 
 DEFAULT_W3D = 'DefaultW3D.fx'
 

--- a/io_mesh_w3d/common/utils/material_import.py
+++ b/io_mesh_w3d/common/utils/material_import.py
@@ -5,8 +5,8 @@ import bpy
 import bmesh
 from bpy_extras import node_shader_utils
 
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.w3d.structs.mesh_structs.vertex_material import *
+from ...common.utils.helpers import *
+from ...w3d.structs.mesh_structs.vertex_material import *
 
 
 ##########################################################################
@@ -77,7 +77,7 @@ def create_vertex_material(context, principleds, structure, mesh, b_mesh, name, 
     # Iterate through all materials and set their blend mode to Alpha Clip for transparency
     for material in mesh.materials:
         if material:
-            material.blend_method = 'CLIP'
+            set_blend_method(material, 'CLIP')
 
 
 def create_material_from_vertex_material(name, vert_mat):
@@ -89,8 +89,8 @@ def create_material_from_vertex_material(name, vert_mat):
 
     material = bpy.data.materials.new(name)
     material.material_type = 'VERTEX_MATERIAL'
-    material.use_nodes = True
-    material.show_transparent_back = False
+    enable_nodes(material)
+    set_transparency_overlap(material, False)
 
     attributes = {'DEFAULT'}
     attribs = vert_mat.vm_info.attributes
@@ -136,8 +136,8 @@ def create_material_from_shader_material(context, name, shader_mat):
 
     material = bpy.data.materials.new(name)
     material.material_type = 'SHADER_MATERIAL'
-    material.use_nodes = True
-    material.show_transparent_back = False
+    enable_nodes(material)
+    set_transparency_overlap(material, False)
 
     material.technique = shader_mat.header.technique
 

--- a/io_mesh_w3d/common/utils/mesh_export.py
+++ b/io_mesh_w3d/common/utils/mesh_export.py
@@ -6,9 +6,9 @@ import bmesh
 from mathutils import Vector, Matrix
 from bpy_extras import node_shader_utils
 
-from io_mesh_w3d.common.structs.mesh import *
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.common.utils.material_export import *
+from ...common.structs.mesh import *
+from ...common.utils.helpers import *
+from ...common.utils.material_export import *
 
 
 def retrieve_meshes(context, hierarchy, rig, container_name, force_vertex_materials=False):
@@ -219,7 +219,7 @@ def retrieve_meshes(context, hierarchy, rig, container_name, force_vertex_materi
             for j, face in enumerate(b_mesh.faces):
                 for loop in face.loops:
                     vert_index = mesh_struct.triangles[j].vert_ids[loop.index % 3]
-                    stage.tx_coords[0][vert_index] = uv_layer.data[loop.index].uv.copy()
+                    stage.tx_coords[0][vert_index] = get_uv(uv_layer, loop.index).copy()
             tx_stages.append(stage)
 
         b_mesh.free()
@@ -275,7 +275,7 @@ def retrieve_meshes(context, hierarchy, rig, container_name, force_vertex_materi
 
             mesh_struct.material_passes.append(mat_pass)
 
-        for layer in mesh.vertex_colors:
+        for layer in get_vertex_color_layers(mesh):
             if '_' in layer.name:
                 index = int(layer.name.split('_')[-1])
             else:
@@ -385,13 +385,13 @@ def split_multi_uv_vertices(context, mesh, b_mesh):
         ver.select_set(False)
 
     for i, uv_layer in enumerate(mesh.uv_layers):
-        tx_coords = [None] * len(uv_layer.data)
+        tx_coords = [None] * get_uv_count(uv_layer)
         for j, face in enumerate(b_mesh.faces):
             for loop in face.loops:
                 vert_index = mesh.polygons[j].vertices[loop.index % 3]
                 if tx_coords[vert_index] is None:
-                    tx_coords[vert_index] = uv_layer.data[loop.index].uv
-                elif tx_coords[vert_index] != uv_layer.data[loop.index].uv:
+                    tx_coords[vert_index] = get_uv(uv_layer, loop.index).copy()
+                elif tx_coords[vert_index] != get_uv(uv_layer, loop.index):
                     b_mesh.verts[vert_index].select_set(True)
                     vert_index2 = mesh.polygons[j].vertices[(loop.index + 1) % 3]
                     b_mesh.verts[vert_index2].select_set(True)

--- a/io_mesh_w3d/common/utils/mesh_import.py
+++ b/io_mesh_w3d/common/utils/mesh_import.py
@@ -3,7 +3,7 @@
 
 import bpy
 import bmesh
-from io_mesh_w3d.common.utils.material_import import *
+from ...common.utils.material_import import *
 
 
 def create_mesh(context, mesh_struct, coll):
@@ -23,7 +23,8 @@ def create_mesh(context, mesh_struct, coll):
         context.warning("Mesh name automatically fixed due to duplication, new name: " + actual_mesh_name)
 
     mesh.normals_split_custom_set_from_vertices(mesh_struct.normals)
-    if bpy.app.version < (4, 2, 0):
+    # 'use_auto_smooth' was removed in Blender 4.1, custom split normals are always used since then
+    if bpy.app.version < (4, 1, 0):
         mesh.use_auto_smooth = True
 
     mesh.object_type = 'MESH'
@@ -169,7 +170,7 @@ def rig_mesh(mesh_struct, hierarchy, rig, sub_object=None):
 def create_vertex_color_layer(mesh, colors, name, index):
     if not colors:
         return
-    layer = mesh.vertex_colors.new(name=f'{name}_{index}')
+    layer = new_vertex_color_layer(mesh, f'{name}_{index}')
 
     for i, loop in enumerate(mesh.loops):
         layer.data[i].color = colors[loop.vertex_index].to_vector_rgba()

--- a/io_mesh_w3d/export_utils.py
+++ b/io_mesh_w3d/export_utils.py
@@ -1,14 +1,14 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.common.structs.data_context import *
+from .common.structs.data_context import *
 
-from io_mesh_w3d.common.utils.mesh_export import *
-from io_mesh_w3d.common.utils.hierarchy_export import *
-from io_mesh_w3d.common.utils.animation_export import *
-from io_mesh_w3d.common.utils.hlod_export import *
-from io_mesh_w3d.common.utils.box_export import *
-from io_mesh_w3d.w3d.utils.dazzle_export import *
+from .common.utils.mesh_export import *
+from .common.utils.hierarchy_export import *
+from .common.utils.animation_export import *
+from .common.utils.hlod_export import *
+from .common.utils.box_export import *
+from .w3d.utils.dazzle_export import *
 
 
 def save_data(context, export_settings):

--- a/io_mesh_w3d/geometry_export.py
+++ b/io_mesh_w3d/geometry_export.py
@@ -2,10 +2,10 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 import bpy
-from io_mesh_w3d.utils import ReportHelper
+from .utils import ReportHelper
 from bpy_extras.io_utils import ExportHelper
-from io_mesh_w3d.w3x.io_xml import *
-from io_mesh_w3d.common.utils.helpers import *
+from .w3x.io_xml import *
+from .common.utils.helpers import *
 
 
 def format_str(value):

--- a/io_mesh_w3d/import_utils.py
+++ b/io_mesh_w3d/import_utils.py
@@ -3,11 +3,11 @@
 
 import bpy
 
-from io_mesh_w3d.common.utils.mesh_import import *
-from io_mesh_w3d.common.utils.hierarchy_import import *
-from io_mesh_w3d.common.utils.animation_import import *
-from io_mesh_w3d.common.utils.box_import import *
-from io_mesh_w3d.w3d.utils.dazzle_import import *
+from .common.utils.mesh_import import *
+from .common.utils.hierarchy_import import *
+from .common.utils.animation_import import *
+from .common.utils.box_import import *
+from .w3d.utils.dazzle_import import *
 
 
 def create_data(context, meshes, hlod=None, hierarchy=None, boxes=None, animation=None, compressed_animation=None,

--- a/io_mesh_w3d/w3d/import_w3d.py
+++ b/io_mesh_w3d/w3d/import_w3d.py
@@ -1,14 +1,14 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.import_utils import *
-from io_mesh_w3d.common.structs.collision_box import *
-from io_mesh_w3d.common.structs.data_context import *
-from io_mesh_w3d.common.structs.hierarchy import *
-from io_mesh_w3d.common.structs.hlod import *
-from io_mesh_w3d.common.structs.mesh import *
-from io_mesh_w3d.w3d.structs.dazzle import *
-from io_mesh_w3d.w3d.structs.compressed_animation import *
+from ..import_utils import *
+from ..common.structs.collision_box import *
+from ..common.structs.data_context import *
+from ..common.structs.hierarchy import *
+from ..common.structs.hlod import *
+from ..common.structs.mesh import *
+from ..w3d.structs.dazzle import *
+from ..w3d.structs.compressed_animation import *
 
 
 def load_file(context, data_context, path=None):

--- a/io_mesh_w3d/w3d/structs/compressed_animation.py
+++ b/io_mesh_w3d/w3d/structs/compressed_animation.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.structs.version import Version
-from io_mesh_w3d.w3d.utils.helpers import *
+from ...w3d.structs.version import Version
+from ...w3d.utils.helpers import *
 
 W3D_CHUNK_COMPRESSED_ANIMATION = 0x00000280
 W3D_CHUNK_COMPRESSED_ANIMATION_HEADER = 0x00000281

--- a/io_mesh_w3d/w3d/structs/dazzle.py
+++ b/io_mesh_w3d/w3d/structs/dazzle.py
@@ -1,7 +1,7 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.utils.helpers import *
+from ...w3d.utils.helpers import *
 
 W3D_CHUNK_DAZZLE = 0x00000900
 W3D_CHUNK_DAZZLE_NAME = 0x00000901

--- a/io_mesh_w3d/w3d/structs/mesh_structs/material_info.py
+++ b/io_mesh_w3d/w3d/structs/mesh_structs/material_info.py
@@ -1,7 +1,7 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.utils.helpers import *
+from ....w3d.utils.helpers import *
 
 W3D_CHUNK_MATERIAL_INFO = 0x00000028
 

--- a/io_mesh_w3d/w3d/structs/mesh_structs/material_pass.py
+++ b/io_mesh_w3d/w3d/structs/mesh_structs/material_pass.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.common.structs.rgba import RGBA
-from io_mesh_w3d.w3d.utils.helpers import *
+from ....common.structs.rgba import RGBA
+from ....w3d.utils.helpers import *
 
 W3D_CHUNK_TEXTURE_STAGE = 0x00000048
 W3D_CHUNK_TEXTURE_IDS = 0x00000049

--- a/io_mesh_w3d/w3d/structs/mesh_structs/prelit.py
+++ b/io_mesh_w3d/w3d/structs/mesh_structs/prelit.py
@@ -1,11 +1,11 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.common.structs.mesh_structs.texture import *
-from io_mesh_w3d.w3d.structs.mesh_structs.material_info import *
-from io_mesh_w3d.w3d.structs.mesh_structs.material_pass import *
-from io_mesh_w3d.w3d.structs.mesh_structs.shader import *
-from io_mesh_w3d.w3d.structs.mesh_structs.vertex_material import *
+from ....common.structs.mesh_structs.texture import *
+from ....w3d.structs.mesh_structs.material_info import *
+from ....w3d.structs.mesh_structs.material_pass import *
+from ....w3d.structs.mesh_structs.shader import *
+from ....w3d.structs.mesh_structs.vertex_material import *
 
 W3D_CHUNK_PRELIT_UNLIT = 0x00000023
 W3D_CHUNK_PRELIT_VERTEX = 0x00000024

--- a/io_mesh_w3d/w3d/structs/mesh_structs/shader.py
+++ b/io_mesh_w3d/w3d/structs/mesh_structs/shader.py
@@ -1,7 +1,7 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.io_binary import *
+from ....w3d.io_binary import *
 
 W3D_CHUNK_SHADERS = 0x00000029
 

--- a/io_mesh_w3d/w3d/structs/mesh_structs/vertex_material.py
+++ b/io_mesh_w3d/w3d/structs/mesh_structs/vertex_material.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.common.structs.rgba import RGBA
-from io_mesh_w3d.w3d.utils.helpers import *
+from ....common.structs.rgba import RGBA
+from ....w3d.utils.helpers import *
 
 W3D_CHUNK_VERTEX_MATERIALS = 0x0000002A
 W3D_CHUNK_VERTEX_MATERIAL_INFO = 0x0000002D

--- a/io_mesh_w3d/w3d/structs/version.py
+++ b/io_mesh_w3d/w3d/structs/version.py
@@ -1,7 +1,7 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.io_binary import *
+from ...w3d.io_binary import *
 
 
 class Version:

--- a/io_mesh_w3d/w3d/utils/dazzle_export.py
+++ b/io_mesh_w3d/w3d/utils/dazzle_export.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.common.utils.helpers import *
-from io_mesh_w3d.w3d.structs.dazzle import *
+from ...common.utils.helpers import *
+from ...w3d.structs.dazzle import *
 
 
 def retrieve_dazzles(container_name):

--- a/io_mesh_w3d/w3d/utils/dazzle_import.py
+++ b/io_mesh_w3d/w3d/utils/dazzle_import.py
@@ -3,8 +3,8 @@
 
 import bpy
 from bpy_extras import node_shader_utils
-from io_mesh_w3d.common.utils.primitives import *
-from io_mesh_w3d.common.utils.helpers import *
+from ...common.utils.primitives import *
+from ...common.utils.helpers import *
 
 
 def create_dazzle(context, dazzle, coll):
@@ -15,9 +15,9 @@ def create_dazzle(context, dazzle, coll):
     link_object_to_active_scene(dazzle_cone, coll)
 
     material = bpy.data.materials.new(dazzle.name())
-    material.use_nodes = True
-    material.blend_method = 'BLEND'
-    material.show_transparent_back = False
+    enable_nodes(material)
+    set_blend_method(material, 'BLEND')
+    set_transparency_overlap(material, False)
 
     principled = node_shader_utils.PrincipledBSDFWrapper(material, is_readonly=False)
     principled.base_color = (255, 255, 255)

--- a/io_mesh_w3d/w3d/utils/helpers.py
+++ b/io_mesh_w3d/w3d/utils/helpers.py
@@ -1,7 +1,7 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3d.io_binary import *
+from ...w3d.io_binary import *
 
 
 def skip_unknown_chunk(context, io_stream, chunk_type, chunk_size):

--- a/io_mesh_w3d/w3x/export_w3x.py
+++ b/io_mesh_w3d/w3x/export_w3x.py
@@ -1,8 +1,8 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.export_utils import *
-from io_mesh_w3d.w3x.structs.include import *
+from ..export_utils import *
+from ..w3x.structs.include import *
 
 
 def save(context, export_settings, data_context):

--- a/io_mesh_w3d/w3x/import_w3x.py
+++ b/io_mesh_w3d/w3x/import_w3x.py
@@ -1,17 +1,17 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.import_utils import *
-from io_mesh_w3d.common.structs.animation import *
-from io_mesh_w3d.common.structs.collision_box import *
-from io_mesh_w3d.common.structs.data_context import *
-from io_mesh_w3d.common.structs.hierarchy import *
-from io_mesh_w3d.common.structs.hlod import *
-from io_mesh_w3d.common.structs.mesh import *
-from io_mesh_w3d.common.structs.mesh_structs.texture import *
-from io_mesh_w3d.w3x.structs.include import *
-from io_mesh_w3d.common.utils.hierarchy_export import *
-from io_mesh_w3d.common.utils.hlod_export import *
+from ..import_utils import *
+from ..common.structs.animation import *
+from ..common.structs.collision_box import *
+from ..common.structs.data_context import *
+from ..common.structs.hierarchy import *
+from ..common.structs.hlod import *
+from ..common.structs.mesh import *
+from ..common.structs.mesh_structs.texture import *
+from ..w3x.structs.include import *
+from ..common.utils.hierarchy_export import *
+from ..common.utils.hlod_export import *
 
 
 def load_file(context, data_context, path=None):

--- a/io_mesh_w3d/w3x/io_xml.py
+++ b/io_mesh_w3d/w3x/io_xml.py
@@ -17,7 +17,8 @@ def write_struct(struct, path):
 
 def pretty_print(elem, level=0):
     i = '\n' + level * '  '
-    if elem:
+    # testing the truth value of an element is deprecated, check the child count instead
+    if len(elem):
         elem.text = i + '  '
         elem.tail = i
         for elem in elem:

--- a/io_mesh_w3d/w3x/structs/include.py
+++ b/io_mesh_w3d/w3x/structs/include.py
@@ -1,7 +1,7 @@
 # <pep8 compliant>
 # Written by Stephan Vedder and Michael Schnabel
 
-from io_mesh_w3d.w3x.io_xml import *
+from ...w3x.io_xml import *
 
 
 class Include:

--- a/io_mesh_w3d/w3x/structs/mesh_structs/bounding_box.py
+++ b/io_mesh_w3d/w3x/structs/mesh_structs/bounding_box.py
@@ -2,7 +2,7 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector
-from io_mesh_w3d.w3x.io_xml import *
+from ....w3x.io_xml import *
 
 
 class BoundingBox:

--- a/io_mesh_w3d/w3x/structs/mesh_structs/bounding_sphere.py
+++ b/io_mesh_w3d/w3x/structs/mesh_structs/bounding_sphere.py
@@ -2,7 +2,7 @@
 # Written by Stephan Vedder and Michael Schnabel
 
 from mathutils import Vector
-from io_mesh_w3d.w3x.io_xml import *
+from ....w3x.io_xml import *
 
 
 class BoundingSphere:

--- a/tests/common/cases/utils/test_mesh_export.py
+++ b/tests/common/cases/utils/test_mesh_export.py
@@ -335,8 +335,8 @@ class TestMeshExportUtils(TestCase):
         tx_coords = [get_vec2(0.0, 0.0)] * 24
 
         uv_layer = mesh.uv_layers.new(do_init=False)
-        for i, datum in enumerate(uv_layer.data):
-            datum.uv = tx_coords[i]
+        for i in range(get_uv_count(uv_layer)):
+            set_uv(uv_layer, i, tx_coords[i])
 
         _mesh = prepare_bmesh(self, mesh)
 
@@ -431,8 +431,8 @@ class TestMeshExportUtils(TestCase):
 
         uv_layer = mesh.uv_layers.new(do_init=False)
 
-        for i, datum in enumerate(uv_layer.data):
-            datum.uv = tx_coords[i]
+        for i in range(get_uv_count(uv_layer)):
+            set_uv(uv_layer, i, tx_coords[i])
 
         _mesh = prepare_bmesh(self, mesh)
 
@@ -453,8 +453,8 @@ class TestMeshExportUtils(TestCase):
         b_mesh.to_mesh(mesh)
 
         uv_layer = mesh.uv_layers.new(do_init=False)
-        for datum in uv_layer.data:
-            datum.uv = Vector((0.0, 0.1))
+        for i in range(get_uv_count(uv_layer)):
+            set_uv(uv_layer, i, Vector((0.0, 0.1)))
 
         mesh_ob = bpy.data.objects.new('mesh_object', mesh)
         mesh_ob.data.object_type = 'MESH'
@@ -685,7 +685,7 @@ class TestMeshExportUtils(TestCase):
         create_mesh(self, mesh, get_collection())
 
         mesh = bpy.data.objects['mesh'].data
-        mesh.vertex_colors.new(name='invalid')
+        new_vertex_color_layer(mesh, 'invalid')
 
         with (patch.object(self, 'warning')) as report_func:
             meshes, _ = retrieve_meshes(self, None, None, 'container_name')

--- a/tests/common/cases/utils/test_mesh_import.py
+++ b/tests/common/cases/utils/test_mesh_import.py
@@ -241,14 +241,16 @@ class TestMeshImportUtils(TestCase):
 
         mesh = bpy.data.objects[mesh_name].data
 
-        self.assertEqual(6, len(mesh.vertex_colors))
+        layers = get_vertex_color_layers(mesh)
 
-        self.assertEqual('DCG_0', mesh.vertex_colors[0].name)
-        self.assertEqual('DIG_0', mesh.vertex_colors[1].name)
-        self.assertEqual('SCG_0', mesh.vertex_colors[2].name)
-        self.assertEqual('DCG_1', mesh.vertex_colors[3].name)
-        self.assertEqual('DIG_1', mesh.vertex_colors[4].name)
-        self.assertEqual('SCG_1', mesh.vertex_colors[5].name)
+        self.assertEqual(6, len(layers))
+
+        self.assertEqual('DCG_0', layers[0].name)
+        self.assertEqual('DIG_0', layers[1].name)
+        self.assertEqual('SCG_0', layers[2].name)
+        self.assertEqual('DCG_1', layers[3].name)
+        self.assertEqual('DIG_1', layers[4].name)
+        self.assertEqual('SCG_1', layers[5].name)
 
     def test_mesh_import_tx_stage_has_no_tx_coords(self):
         mesh_name = 'mesh'


### PR DESCRIPTION
Verified against Blender 5.2.0 LTS (Python 3.13): the full test suite, an install as extension and as legacy add-on, and a W3D/W3X export and re-import roundtrip.

Replace all deprecated API usage, so the add-on no longer emits a single deprecation warning on 5.2:

* Material.blend_method -> Material.surface_render_method. The old property has no effect in EEVEE Next, so transparency of imported materials was silently lost since Blender 4.2.
* Material.show_transparent_back -> Material.use_transparency_overlap
* Material.use_nodes, which gets removed in Blender 6.0. The node tree is only requested when the material does not have one yet.
* Mesh.vertex_colors -> Mesh.color_attributes
* MeshUVLoopLayer.data -> MeshUVLoopLayer.uv

All of them go through version guarded helpers, the add-on keeps working on the older Blender versions the CI covers.

Make the add-on installable as an extension:

* add blender_manifest.toml, the released archive now works both as an extension (Blender 4.2+) and as a legacy add-on archive.
* use relative imports inside the package. As an extension the package is named bl_ext.<repo>.io_mesh_w3d, so the absolute io_mesh_w3d.* imports failed to resolve and enabling the add-on errored out.
* skip the bundled updater when running as an extension, extensions are updated through their repository instead.

Bugfixes found along the way:

* import crashed on Blender 4.1: Mesh.use_auto_smooth was removed in 4.1, not in 4.2 as the version guard assumed.
* w3x writing relied on the truth value of an xml element, which is deprecated in Python and will always be True in a future version. Reading it as a child count keeps the intended meaning.